### PR TITLE
Rename deprecated gevent.coros with gevent.lock

### DIFF
--- a/lib/connpool.py
+++ b/lib/connpool.py
@@ -1,7 +1,7 @@
 import logging
 
 import gevent
-from gevent.coros import BoundedSemaphore
+from gevent.lock import BoundedSemaphore
 from gevent import socket
 from collections import deque
 from contextlib import contextmanager


### PR DESCRIPTION
Rename deprecated gevent.coros with gevent.lock

gevent.coros is deprecated and removed in the latest versions http://www.gevent.org/whatsnew_1_0.html