### PR TITLE
Kill hanging servers in case of errors

### DIFF
--- a/lib/inspector.py
+++ b/lib/inspector.py
@@ -98,6 +98,8 @@ class TarantoolInspector(StreamServer):
                 color_stdout('\nTarantoolInpector.handle() received the following error:\n' +
                     traceback.format_exc() + '\n', schema='error')
                 result = { "error": repr(e) }
+                self.parser.kill_current_test()
+                self.parser.stop_nondefault()
             if result == None:
                 result = True
             result = yaml.dump(result)

--- a/lib/test.py
+++ b/lib/test.py
@@ -170,12 +170,12 @@ class Test:
         except TestExecutionError:
             self.is_executed_ok = False
         except Exception as e:
-            if e.__class__.__name__ == 'TarantoolStartError':
-                # worker should stop
-                raise
             color_stdout('\nTest.run() received the following error:\n' +
                 traceback.format_exc() + '\n', schema='error')
             diagnostics = str(e)
+            if e.__class__.__name__ == 'TarantoolStartError':
+                # worker should stop
+                raise
         finally:
             if sys.stdout and sys.stdout != save_stdout:
                 sys.stdout.close()

--- a/lib/unittest_server.py
+++ b/lib/unittest_server.py
@@ -47,7 +47,7 @@ class UnittestServer(Server):
     def prepare_args(self):
         return [os.path.join(self.builddir, "test", self.current_test.name)]
 
-    def deploy(self, vardir=None, silent=True, wait=True):
+    def deploy(self, vardir=None, silent=True, wait_load=True):
         self.vardir = vardir
         if not os.access(self.vardir, os.F_OK):
             os.makedirs(self.vardir)

--- a/lib/worker.py
+++ b/lib/worker.py
@@ -228,7 +228,9 @@ class Worker:
         try:
             self.suite.stop_server(self.server, self.inspector, silent=silent,
                                    cleanup=cleanup)
-        except (KeyboardInterrupt, Exception):
+        except (KeyboardInterrupt, Exception) as e:
+            color_stdout("The raised exception is '%s' of type '%s'.\n"
+                         % (str(e), str(type(e))), schema='error')
             if rais:
                 raise
 

--- a/test_run.lua
+++ b/test_run.lua
@@ -90,15 +90,19 @@ local function wait_vclock(self, node, to_vclock)
 end
 
 
-local create_cluster_cmd1 = 'create server %s with script="%s/%s.lua",' ..
-                            ' wait_load=False, wait=False'
-local create_cluster_cmd2 = 'start server %s'
+local create_and_dont_wait_cmd = 'create server %s with script="%s/%s.lua", wait_load=False'
+local create_and_wait_cmd      = 'create server %s with script="%s/%s.lua", wait_load=True'
+local start_cluster_cmd        = 'start server %s'
 
-local function create_cluster(self, servers, test_suite)
+local function create_cluster(self, servers, test_suite, wait)
     test_suite = test_suite or 'replication'
     for _, name in ipairs(servers) do
-        self:cmd(create_cluster_cmd1:format(name, test_suite, name))
-        self:cmd(create_cluster_cmd2:format(name))
+        if wait then
+            self:cmd(create_and_wait_cmd:format(name, test_suite, name))
+        else
+            self:cmd(create_and_dont_wait_cmd:format(name, test_suite, name))
+        end
+        self:cmd(start_cluster_cmd:format(name))
     end
 end
 


### PR DESCRIPTION
Solves issue #65.
Prints error messages from servers + last lines of tarantool log in case of an error