### PR TITLE
Handle non-default server crash

### DIFF
--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -50,6 +50,8 @@ def save_join(green_obj, timeout=None):
         green_obj.join(timeout=timeout)
     except GreenletExit:
         return True
+    except TarantoolStartError:
+        return True
     return False
 
 


### PR DESCRIPTION
TarantoolStartError is subject to propagate to a joining greenlet,
consider `lib.inspector.gevent_propagate_exc()`.