### PR TITLE
Don't abort if 'start server' command fails

### DIFF
--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -161,12 +161,12 @@ class TestState(object):
         args = []
         if 'args' in opts:
             args = opts['args'][1:-1].split(' ')
-        self.servers[sname].start(silent=True, rais=True, wait=wait, wait_load=wait_load, args=args)
-        self.connections[sname] = self.servers[sname].admin
         try:
+            self.servers[sname].start(silent=True, rais=True, wait=wait, wait_load=wait_load, args=args)
+            self.connections[sname] = self.servers[sname].admin
             self.connections[sname]('return true', silent=True)
-        except socket.error as e:
-            LuaPreprocessorException('Can\'t start server '+repr(sname))
+        except:
+            return 'Can\'t start server ' + repr(sname)
 
     def server_stop(self, ctype, sname, opts):
         color_log('\nDEBUG: TestState[%s].server_stop(%s, %s, %s)\n' % (

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -567,12 +567,6 @@ class TarantoolServer(Server):
                                         stdout=self.log_des,
                                         stderr=self.log_des)
 
-        # gh-19 crash detection
-        self.crash_detector = TestRunGreenlet(self.crash_detect)
-        self.crash_detector.info = "Crash detector: %s" % self.process
-        self.crash_detector.start()
-        wait = wait
-        wait_load = wait_load
         if wait:
             try:
                 self.wait_until_started(wait_load)
@@ -596,6 +590,11 @@ class TarantoolServer(Server):
                 if not self.current_test:
                     raise
                 self.kill_current_test()
+
+        # gh-19 crash detection
+        self.crash_detector = TestRunGreenlet(self.crash_detect)
+        self.crash_detector.info = "Crash detector: %s" % self.process
+        self.crash_detector.start()
 
         port = self.admin.port
         self.admin.disconnect()


### PR DESCRIPTION
Sometimes, it is useful to check that a tarantool replica fails to start
under certain conditions, but currently it is impossible to do so in
Lua, because test_run:cmd('start server') aborts the test in this case.
This patch makes it print an error message to the result file instead.

Closes #92