### PR TITLE
Support expected fail of non-default server

### DIFF
--- a/lib/worker.py
+++ b/lib/worker.py
@@ -269,7 +269,7 @@ class Worker:
             raise
         except Exception as e:
             color_stdout(
-                'Worker "%s" received the following error; stopping...\n'
+                '\nWorker "%s" received the following error; stopping...\n'
                 % self.name + traceback.format_exc() + '\n', schema='error')
             raise
         return short_status


### PR DESCRIPTION
Usage:

```
test_run:cmd("start server <name> with crash_expected=True")
```

Also fixed non-default server crash reporting, regression after
9d73ef1281c59177c7c23aae1371e71b4038e7f1

Fixes #92.