### PR TITLE
Fix format_process function

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -170,6 +170,8 @@ def format_process(pid):
     try:
         with open('/proc/%d/status' % pid, 'r') as f:
             for line in f:
+                if ':' not in line:
+                    continue
                 key, value = line.split(':', 1)
                 if key == 'State':
                     status = value.strip()


### PR DESCRIPTION
Found empty lines in /proc/.../status on one Ubuntu 16.04 installation.