### PR TITLE
test-run: do not reset grep_log on restart

### DIFF
--- a/test_run.lua
+++ b/test_run.lua
@@ -215,7 +215,7 @@ local function get_cfg(self, name)
     return self.run_conf[name]
 end
 
-local function grep_log(self, node, what, bytes)
+local function grep_log(self, node, what, bytes, noreset)
     local filename = self:eval(node, "box.cfg.log")[1]
     local file = fio.open(filename, {'O_RDONLY', 'O_NONBLOCK'})
 
@@ -240,7 +240,8 @@ local function grep_log(self, node, what, bytes)
     if file:seek(-bytes, 'SEEK_END') == nil then
         fail("Failed to seek log file")
     end
-    local found, buf
+    local buf, found = nil
+    local noreset = noreset or false
     repeat -- read file in chunks
         local s = file:read(2048)
         if s == nil then
@@ -262,7 +263,7 @@ local function grep_log(self, node, what, bytes)
                     line = table.concat(buf)
                     buf = nil
                 end
-                if string.match(line, "Starting instance") then
+                if string.match(line, "Starting instance") and not noreset then
                     found = nil -- server was restarted, reset search
                 else
                     found = string.match(line, what) or found


### PR DESCRIPTION
Current 'grep_log' behaviour resets search result then server was
restarted.
Suggest to extend this behaviour with optional noreset parameter.
This option needed to test specific behaviout on server shutdown.

Needed for #3159