### PR TITLE
Allow to pass arguments to create_cluster.

### DIFF
--- a/test_run.lua
+++ b/test_run.lua
@@ -94,6 +94,7 @@ local create_cluster_cmd1 = 'create server %s with script="%s/%s.lua"'
 local create_cluster_cmd1_return_listen_uri =
     'create server %s with script="%s/%s.lua", return_listen_uri=True'
 local create_cluster_cmd2 = 'start server %s with wait_load=False, wait=False'
+local create_cluster_cmd2_args = create_cluster_cmd2 .. ', args="%s"'
 
 local function create_cluster(self, servers, test_suite, opts)
     local opts = opts or {}
@@ -108,7 +109,13 @@ local function create_cluster(self, servers, test_suite, opts)
         else
             self:cmd(create_cluster_cmd1:format(name, test_suite, name))
         end
-        self:cmd(create_cluster_cmd2:format(name))
+    end
+    for _, name in ipairs(servers) do
+        if opts.args then
+            self:cmd(create_cluster_cmd2_args:format(name, opts.args))
+        else
+            self:cmd(create_cluster_cmd2:format(name))
+        end
     end
 
     if opts.return_listen_uri then


### PR DESCRIPTION
Just like in case of `start server replica with args='1 2 3'`, it is
now possible to pass arguments to create_cluster, so that all instances
are started whith these arguments.

Also alter create_cluster a little bit: previous behaviour was to create
and start instances in a loop, change it to first creating all
instances and then starting them. This is needed because creating an
instance may take up a lot of time, if the old vardir isn't empty, and
the first started instance would have to wait for others for a
significant period of time, which makes it exit upon timeout if
replication_connect_timeout is relatively small.

Needed for tarantool/tarantool#3428