### PR TITLE
Add new config param 'show_reproduce_content'

### DIFF
--- a/lib/test_suite.py
+++ b/lib/test_suite.py
@@ -99,6 +99,9 @@ class TestSuite:
             self.ini[i] = map(lambda x: os.path.join(suite_path, x),
                     dict.fromkeys(self.ini[i].split()) if i in self.ini else dict())
 
+        self.ini.update(
+            dict(show_reproduce_content=self.show_reproduce_content()))
+
     def find_tests(self):
         if self.ini['core'] == 'tarantool':
             TarantoolServer.find_tests(self, self.suite_path)
@@ -205,12 +208,23 @@ class TestSuite:
         return short_status
 
     def is_parallel(self):
-        val = self.ini.get('is_parallel', 'False').lower()
-        if val == 'true':
-            val = True
-        elif val == 'false':
-            val = False
-        else:
-            raise ConfigurationError()
-            pass
-        return val
+        val = self.ini.get('is_parallel', 'false')
+        if isinstance(val, bool):
+            return val
+        # If value is not boolean it come from ini file, need to
+        # convert string 'True' or 'False' into boolean representation
+        if val.lower() not in ['true', 'false']:
+            raise ConfigurationError('is_parallel', val, "'True' or 'False'")
+        return val.lower() == 'true'
+
+    def show_reproduce_content(self):
+        val = self.ini.get('show_reproduce_content', 'true')
+        if isinstance(val, bool):
+            return val
+        # If value is not boolean it come from ini file, need to
+        # convert string 'True' or 'False' into boolean representation
+        if val.lower() not in ['true', 'false']:
+            raise ConfigurationError('show_reproduce_content',
+                                     val,
+                                     "'True' or 'False'")
+        return val.lower() == 'true'

--- a/lib/worker.py
+++ b/lib/worker.py
@@ -78,6 +78,7 @@ def get_task_groups():
                 'gen_worker': gen_worker,
                 'task_ids': task_ids,
                 'is_parallel': suite.is_parallel(),
+                'show_reproduce_content': suite.show_reproduce_content()
             }
     return res
 
@@ -131,12 +132,14 @@ class WorkerTaskResult(BaseWorkerMessage):
     worker. The short_status (string) field intended to give short note whether
     the task processed successfully or not, but with little more flexibility
     than binary True/False. The task_id (any hashable object) field hold ID of
-    the processed task.
+    the processed task. The show_reproduce_content configuration form suite.ini
     """
-    def __init__(self, worker_id, worker_name, task_id, short_status):
+    def __init__(self, worker_id, worker_name, task_id,
+                 short_status, show_reproduce_content):
         super(WorkerTaskResult, self).__init__(worker_id, worker_name)
         self.short_status = short_status
         self.task_id = task_id
+        self.show_reproduce_content = show_reproduce_content
 
 
 class WorkerOutput(BaseWorkerMessage):
@@ -198,7 +201,8 @@ class Worker:
                                  task_name, task_param, task_result_filepath)
 
     def wrap_result(self, task_id, short_status):
-        return WorkerTaskResult(self.id, self.name, task_id, short_status)
+        return WorkerTaskResult(self.id, self.name, task_id, short_status,
+                                self.suite.show_reproduce_content())
 
     def sigterm_handler(self, signum, frame):
         self.sigterm_received = True

--- a/listeners.py
+++ b/listeners.py
@@ -40,7 +40,9 @@ class StatisticsWatcher(BaseWatcher):
         self.stats[obj.short_status] += 1
 
         if obj.short_status == 'fail':
-            self.failed_tasks.append((obj.task_id, obj.worker_name))
+            self.failed_tasks.append((obj.task_id,
+                                      obj.worker_name,
+                                      obj.show_reproduce_content))
 
     def print_statistics(self):
         """Returns are there failed tasks."""
@@ -53,15 +55,16 @@ class StatisticsWatcher(BaseWatcher):
             return False
 
         color_stdout('Failed tasks:\n', schema='test_var')
-        for task_id, worker_name in self.failed_tasks:
+        for task_id, worker_name, show_reproduce_content in self.failed_tasks:
             logfile = self.get_logfile(worker_name)
-            reproduce_file_path = get_reproduce_file(worker_name)
             color_stdout('- %s' % yaml.safe_dump(task_id), schema='test_var')
             color_stdout('# logfile:        %s\n' % logfile)
+            reproduce_file_path = get_reproduce_file(worker_name)
             color_stdout('# reproduce file: %s\n' % reproduce_file_path)
-            color_stdout("---\n", schema='separator')
-            lib.utils.print_tail_n(reproduce_file_path)
-            color_stdout("...\n", schema='separator')
+            if show_reproduce_content:
+                color_stdout("---\n", schema='separator')
+                lib.utils.print_tail_n(reproduce_file_path)
+                color_stdout("...\n", schema='separator')
 
         return True
 

--- a/test-run.py
+++ b/test-run.py
@@ -151,6 +151,7 @@ def main_loop_consistent(failed_test_ids):
         color_stdout('-' * 75, "\n",       schema='separator')
 
         task_ids = task_group['task_ids']
+        show_reproduce_content = task_group['show_reproduce_content']
         if not task_ids:
             continue
         worker_id = 1
@@ -162,9 +163,10 @@ def main_loop_consistent(failed_test_ids):
                     lib.worker.get_reproduce_file(worker.name)
                 color_stdout('Reproduce file %s\n' %
                              reproduce_file_path, schema='error')
-                color_stdout("---\n", schema='separator')
-                lib.utils.print_tail_n(reproduce_file_path)
-                color_stdout("...\n", schema='separator')
+                if show_reproduce_content:
+                    color_stdout("---\n", schema='separator')
+                    lib.utils.print_tail_n(reproduce_file_path)
+                    color_stdout("...\n", schema='separator')
                 failed_test_ids.append(task_id)
                 if not lib.Options().args.is_force:
                     worker.stop_server(cleanup=False)


### PR DESCRIPTION
By default this param is True, if the test fails then the contents of
reproduce file are displayed. If the parameter is False, do not show
the contents of reproduce file.  For example, the 'sql-tap' tests run
each case in a separate tarantool instance, so reproduce is not
necessary for problem investigation. Used in 'suite.ini'.

Closes #113