### PR TITLE
test: wait for logs

### DIFF
--- a/test_run.lua
+++ b/test_run.lua
@@ -285,24 +285,21 @@ local function grep_log(self, node, what, bytes, opts)
     return found
 end
 
--- Checks cmp(fn()) with delay until timeout or returns fn().
--- Comparator cmp should return true if it what we waiting for.
-local function wait_cond(self, fn, timeout, delay, cmp)
+-- Checks fn with delay until timeout or fn returns true,
+-- otherwise returns false.
+local function wait_cond(self, fn, timeout, delay)
     assert(type(fn) == 'function')
     assert(timeout ~= nil)
     delay = delay or 0.001
     local t1 = clock.monotonic()
-    local cmp = cmp or function(val) return val end
     local fn_rv = fn()
-    local cpm_rv = cmp(fn_rv)
-    while not cpm_rv do
+    while not fn_rv do
         local work_time = clock.monotonic() - t1
         if work_time > timeout then
             return fn_rv
         end
         fiber.sleep(delay)
         fn_rv = fn()
-        cpm_rv = cmp(fn_rv)
     end
     return fn_rv
 end
@@ -314,8 +311,7 @@ local function wait_log(self, node, what, bytes, timeout, opts)
     local cond = function()
         return grep_log(self, node, what, bytes, opts)
     end
-    local cmp = opts.cmp or function(val) return val ~= nil end
-    return wait_cond(self, cond, timeout, opts.delay, cmp)
+    return wait_cond(self, cond, timeout, opts.delay)
 end
 
 local inspector_methods = {


### PR DESCRIPTION
Instead of sleep by constant time and then checking for some condition
use `wait_cond` to wait for condition in timeout period.

Using `wait_cond` to wrap `grep_log`.