### PR TITLE
Set cloexec before connect

### DIFF
--- a/lib/tarantool_connection.py
+++ b/lib/tarantool_connection.py
@@ -47,11 +47,12 @@ class TarantoolPool(ConnectionPool):
         if self.host == 'unix/' or re.search(r'^/', str(self.port)):
             warn_unix_socket(self.port)
             result = gsocket.socket(gsocket.AF_UNIX, gsocket.SOCK_STREAM)
+            set_fd_cloexec(result.fileno())
             result.connect(self.port)
         else:
             result = gsocket.create_connection((self.host, self.port))
             result.setsockopt(gsocket.SOL_TCP, gsocket.TCP_NODELAY, 1)
-        set_fd_cloexec(result)
+            set_fd_cloexec(result.fileno())
         return result
 
     def _addOne(self):
@@ -109,11 +110,12 @@ class TarantoolConnection(object):
     def connect(self):
         if self.host == 'unix/' or re.search(r'^/', str(self.port)):
             self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            set_fd_cloexec(self.socket.fileno())
             self.socket.connect(self.port)
         else:
             self.socket = socket.create_connection((self.host, self.port))
             self.socket.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
-        set_fd_cloexec(self.socket)
+            set_fd_cloexec(self.socket.fileno())
         self.is_connected = True
 
     def disconnect(self):


### PR DESCRIPTION
When using use_unix_sockets, the file descriptors are not closed after
the default server was restart, and tests that limit number of
open files fail.

Fixes: https://github.com/tarantool/tarantool/issues/3806