### PR TITLE
Add 'use_unix_sockets_iproto' suite.ini option

### DIFF
--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -214,6 +214,7 @@ class TestState(object):
             temp.rpl_master = self.servers[opts['rpl_master']]
         temp.vardir = self.suite_ini['vardir']
         temp.use_unix_sockets = self.suite_ini['use_unix_sockets']
+        temp.use_unix_sockets_iproto = self.suite_ini['use_unix_sockets_iproto']
         temp.inspector_port = int(self.suite_ini.get(
             'inspector_port', temp.DEFAULT_INSPECTOR
         ))

--- a/lib/test_suite.py
+++ b/lib/test_suite.py
@@ -112,6 +112,7 @@ class TestSuite:
 
         self.parse_bool_opt('pre_cleanup', False)
         self.parse_bool_opt('use_unix_sockets', False)
+        self.parse_bool_opt('use_unix_sockets_iproto', False)
         self.parse_bool_opt('is_parallel', False)
         self.parse_bool_opt('show_reproduce_content', True)
 


### PR DESCRIPTION
The existing 'use_unix_sockets' option enables using of unix sockets for
admin (console) sockets. The new option enables it for iproto (binary
protocol) sockets.

The reason why it is done under a separate option is to shield existing
users from unexpected behaviour changes.