### PR TITLE
Fix TARANTOOL_SRC_DIR with recent tarantool

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -15,7 +15,7 @@ __all__ = ['Options']
 
 def setenv():
     """Find where is tarantool dir by check_file"""
-    check_file = 'src/fiber.h'
+    check_file = 'src/trivia/util.h'
     path = os.path.abspath('../')
     while path != '/':
         if os.path.isfile('%s/%s' % (path, check_file)):


### PR DESCRIPTION
src/fiber.h is moved to src/lib/core/fiber.h in 2.1.1-322-g3f5f59bb5,
see [1]. TARANTOOL_SRC_DIR is not set by test-run and
app-tap/http_client.test.lua fails with the following error in logs:

sh: 1: ../../test/app-tap/httpd.py: not found

[1]: https://github.com/tarantool/tarantool/commit/3f5f59bb53908d432659408c746f54cfbf67411e