### PR TITLE
Run a unit test from a var directory

### DIFF
--- a/lib/unittest_server.py
+++ b/lib/unittest_server.py
@@ -14,7 +14,7 @@ class UnitTest(Test):
     def execute(self, server):
         server.current_test = self
         execs = server.prepare_args()
-        proc = Popen(execs, stdout=PIPE, stderr=STDOUT)
+        proc = Popen(execs, cwd=server.vardir, stdout=PIPE, stderr=STDOUT)
         sys.stdout.write(proc.communicate()[0])
 
 class UnittestServer(Server):


### PR DESCRIPTION
It seems natural to set cwd to a var directory for a unit test to, say,
allow it to produce log files that will be under a gitignored directory.

We already run servers for other test suite types (tarantool and app) in
a var directory.