### PR TITLE
Fix _func system space clean

### DIFF
--- a/pretest_clean.lua
+++ b/pretest_clean.lua
@@ -67,7 +67,7 @@ local function clean()
         return name
     end):filter(function(name)
         return not allowed_funcs[name]
-    end):each(function(tuple)
+    end):each(function(name)
         box.schema.func.drop(name)
     end)
 


### PR DESCRIPTION
Before this commit, if there are a registered function, clean() function
fails when pretest_clean option is enabled in suite.ini.