### PR TITLE
Update pyyaml version

### DIFF
--- a/lib/admin_connection.py
+++ b/lib/admin_connection.py
@@ -69,7 +69,7 @@ class ExecMixIn(object):
                 break
 
         try:
-            yaml.load(res)
+            yaml.safe_load(res)
         finally:
             if not silent:
                 sys.stdout.write(res.replace("\r\n", "\n"))

--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -341,7 +341,7 @@ class TestState(object):
         result = self.servers[name].admin(
             '%s%s' % (expr, self.delimiter), silent=silent
         )
-        result = yaml.load(result)
+        result = yaml.safe_load(result)
         if not result:
             result = []
         return result

--- a/lib/pytap13.py
+++ b/lib/pytap13.py
@@ -70,7 +70,7 @@ class TAP13(object):
                 if RE_YAMLISH_END.match(line):
                     test = self.tests[-1]
                     try:
-                        test.yaml = yaml.load(test._yaml_buffer.getvalue())
+                        test.yaml = yaml.safe_load(test._yaml_buffer.getvalue())
                     except Exception as e:
                         if not self.strict:
                             continue

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -805,9 +805,9 @@ class TarantoolServer(Server):
             try:
                 temp = AdminConnection('localhost', self.admin.port)
                 if not wait_load:
-                    ans = yaml.load(temp.execute("2 + 2"))
+                    ans = yaml.safe_load(temp.execute("2 + 2"))
                     return True
-                ans = yaml.load(temp.execute('box.info.status'))[0]
+                ans = yaml.safe_load(temp.execute('box.info.status'))[0]
                 if ans in ('running', 'hot_standby', 'orphan'):
                     return True
                 elif ans in ('loading'):
@@ -897,8 +897,8 @@ class TarantoolServer(Server):
 
     def get_param(self, param=None):
         if param is not None:
-            return yaml.load(self.admin("box.info." + param, silent=True))[0]
-        return yaml.load(self.admin("box.info", silent=True))
+            return yaml.safe_load(self.admin("box.info." + param, silent=True))[0]
+        return yaml.safe_load(self.admin("box.info", silent=True))
 
     def get_lsn(self, node_id):
         nodes = self.get_param("vclock")

--- a/lib/worker.py
+++ b/lib/worker.py
@@ -36,7 +36,7 @@ def parse_reproduce_file(filepath):
         return reproduce
     try:
         with open(filepath, 'r') as f:
-            for task_id in yaml.load(f):
+            for task_id in yaml.safe_load(f):
                 task_name, task_conf = task_id
                 reproduce.append((task_name, task_conf))
     except IOError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==3.10
+PyYAML==5.1
 argparse==1.1
 msgpack-python==0.4.6
 gevent==1.1b5


### PR DESCRIPTION
GitHub warns about pyyaml < 4.2b1, because of CVE-2017-18342:
yaml.load() could cause arbitrary code execution. I think it is not very
important in the case of test-run, because a test code is controlled by
a user, but anyway it is good to be up to date.

Eliminated new pyyaml warnings about using of unsafe yaml.load():
replaced it with yaml.safe_load(). We don't construct Python classes
directly according to yaml tags, so safe_load() fit our needs.