### PR TITLE
Better handle keyboard interrupt

### DIFF
--- a/lib/test_suite.py
+++ b/lib/test_suite.py
@@ -179,14 +179,16 @@ class TestSuite:
         return inspector
 
     def stop_server(self, server, inspector, silent=False, cleanup=True):
-        server.stop(silent=silent)
+        if server:
+            server.stop(silent=silent)
+        if inspector:
+            inspector.stop()
         # don't delete core files or state of the data dir
         # in case of exception, which is raised when the
         # server crashes
-        if inspector:
-            inspector.stop()
-        if cleanup:
+        if cleanup and inspector:
             inspector.cleanup_nondefault()
+        if cleanup and server:
             server.cleanup()
 
     def run_test(self, test, server, inspector):


### PR DESCRIPTION
A worker can be interrupted with SIGINT (by Ctrl+C) at the moment when a
server (TarantoolServer, AppServer or UnittestServer) is not created. In
this case test-run shows the following exception:

 | Process Process-21:
 | Traceback (most recent call last):
 |   File "/usr/lib64/python2.7/multiprocessing/process.py", line 267, in _bootstrap
 |     self.run()
 |   File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
 |     self._target(*self._args, **self._kwargs)
 |   File "/home/alex/projects/tarantool-meta/tarantool/test-run/dispatcher.py", line 378, in _run_worker
 |     worker = self.gen_worker(worker_id)
 |   File "/home/alex/projects/tarantool-meta/tarantool/test-run/lib/worker.py", line 243, in __init__
 |     self.stop_server(cleanup=False)
 |   File "/home/alex/projects/tarantool-meta/tarantool/test-run/lib/worker.py", line 258, in stop_server
 |     cleanup=cleanup)
 |   File "/home/alex/projects/tarantool-meta/tarantool/test-run/lib/test_suite.py", line 182, in stop_server
 |     server.stop(silent=silent)
 | AttributeError: 'NoneType' object has no attribute 'stop'

The commit handles this case and the exception above will not occur
anymore.