### PR TITLE
Fail testing when test-run fails internally

### DIFF
--- a/dispatcher.py
+++ b/dispatcher.py
@@ -237,14 +237,15 @@ class Dispatcher:
             return False
         if verbose:
             color_stdout(
-                'The following tasks were dispatched on some worker task '
+                '[Internal test-run error] '
+                'The following tasks were dispatched to some worker task '
                 'queue, but were not reported as done (does not matters '
                 'success or fail):\n', schema='test_var')
             for task_id in undone:
                 color_stdout('- %s' % yaml.safe_dump(task_id))
         else:
-            color_stdout("Count of didn't processed tasks: %d\n"
-                         % len(undone), schema='test_var')
+            # Visually continue StatisticsWatcher.print_statistics() output.
+            color_stdout('* undone: %d\n' % len(undone), schema='test_var')
         return True
 
     def wait(self):

--- a/test-run.py
+++ b/test-run.py
@@ -107,20 +107,20 @@ def main_loop_parallel():
         dispatcher.wait_processes()
         color_stdout('-' * 81, "\n", schema='separator')
         has_failed = dispatcher.statistics.print_statistics()
-        has_undone = dispatcher.report_undone(verbose=is_force)
+        has_undone = dispatcher.report_undone(verbose=True)
         if has_failed:
             return EXIT_FAILED_TEST
-        if is_force and has_undone:
+        if has_undone:
             return EXIT_NOTDONE_TEST
     except KeyboardInterrupt:
         color_stdout('-' * 81, "\n", schema='separator')
         dispatcher.statistics.print_statistics()
-        dispatcher.report_undone(verbose=is_force)
+        dispatcher.report_undone(verbose=False)
         raise
     except HangError:
         color_stdout('-' * 81, "\n", schema='separator')
         dispatcher.statistics.print_statistics()
-        dispatcher.report_undone(verbose=is_force)
+        dispatcher.report_undone(verbose=True)
         return EXIT_HANG
     return EXIT_SUCCESS
 


### PR DESCRIPTION
This commit handles the case when test-run found that some of scheduled
tasks were not reported as finished by workers. The old behaviour leads
to zero exit code in the case when --force option is not set (looks as
the unintended mistake).

Now this situation causes a testing fail (non-zero exit code) and it
does not matter whether --force option is set.

Show list of failed tasks always except the case when it is caused by a
keyboard interruption.

While we are here clarified and changed related test-run messages.

All that is about the situation that should never occur. See #115 for
such cases.