### PR TITLE
Catch non-default server start fail in app server

### DIFF
--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -9,7 +9,9 @@ from gevent.subprocess import Popen, PIPE
 from lib.colorer import color_log
 from lib.preprocessor import TestState
 from lib.server import Server
-from lib.tarantool_server import Test, TarantoolServer
+from lib.tarantool_server import Test
+from lib.tarantool_server import TarantoolServer
+from lib.tarantool_server import TarantoolStartError
 from lib.utils import find_port
 from lib.utils import format_process
 from test import TestRunGreenlet, TestExecutionError
@@ -38,9 +40,13 @@ class AppTest(Test):
         tarantool = TestRunGreenlet(run_server, execs, server.vardir, server,
                                     server.logfile, retval)
         self.current_test_greenlet = tarantool
-        tarantool.start()
 
-        tarantool.join()
+        try:
+            tarantool.start()
+            tarantool.join()
+        except TarantoolStartError:
+            # A non-default server failed to start.
+            raise TestExecutionError
         if retval['returncode'] != 0:
             raise TestExecutionError
 


### PR DESCRIPTION
When test_run:cmd('start server foo') is called from an app test and
tarantool fails to start, the following exception is shown:

 | [010] Worker "010_app-tap" received the following error; stopping...
 | [010] Traceback (most recent call last):
 | [010]   File "/home/alex/projects/tarantool-meta/tarantool/test-run/lib/worker.py", line 294, in run_task
 | [010]     task, self.server, self.inspector)
 | [010]   File "/home/alex/projects/tarantool-meta/tarantool/test-run/lib/test_suite.py", line 208, in run_test
 | [010]     short_status = test.run(server)
 | [010]   File "/home/alex/projects/tarantool-meta/tarantool/test-run/lib/test.py", line 180, in run
 | [010]     self.execute(server)
 | [010]   File "/home/alex/projects/tarantool-meta/tarantool/test-run/lib/app_server.py", line 43, in execute
 | [010]     tarantool.join()

The commit handles this case and the exception should not be shown
anymore.

This commit follows the similar one for tarantool server: 7176cede ('Fix
reporting of non-default server fail at start ').

The reporting of such situations is not ideal for now (we show output
and logs for a default server, but don't do that for non-default one),
but this will be fixed in the scope of #159.

Fixes #115.