### PR TITLE
Fix killing of servers at crash

### DIFF
--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -101,7 +101,8 @@ class LuaTest(Test):
     def killall_servers(self, server, ts, crash_occured):
         """ kill all servers and crash detectors before stream swap """
         color_log('Kill all servers ...\n', schema='info')
-        check_list = ts.servers.values() + [server, ]
+        server_list = ts.servers.values() + [server, ]
+        check_list = [s for s in server_list if 'process' in s.__dict__]
 
         # check that all servers stopped correctly
         for server in check_list:


### PR DESCRIPTION
We should not try to kill non-default servers that was not started yet.

Before this commit the following exception can occur.

 | [001] Test.run() received the following error:
 | [001] Traceback (most recent call last):
 | [001]   File "/home/alex/projects/tarantool-meta/tarantool/test-run/lib/test.py", line 180, in run
 | [001]     self.execute(server)
 | [001]   File "/home/alex/projects/tarantool-meta/tarantool/test-run/lib/tarantool_server.py", line 154, in execute
 | [001]     self.killall_servers(server, ts, crash_occured)
 | [001]   File "/home/alex/projects/tarantool-meta/tarantool/test-run/lib/tarantool_server.py", line 108, in killall_servers
 | [001]     bad_returncode = server.process.returncode not in (None,
 | [001] AttributeError: 'TarantoolServer' object has no attribute 'process'