### PR TITLE
Show logs for a non-default server failed at start

### DIFF
--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -159,12 +159,9 @@ class LuaTest(Test):
             ts.stop_nondefault()
             raise
         except TarantoolStartError as e:
-            if not self.is_crash_reported:
-                self.is_crash_reported = True
-                color_stdout('\n[Instance "{0}"] Failed to start tarantool '
-                             'server from a test\n'.format(e.name),
-                             schema='error')
-                server.print_log(15)
+            color_stdout('\n[Instance "{0}"] Failed to start tarantool '
+                         'instance "{1}"\n'.format(server.name, e.name),
+                         schema='error')
             server.kill_current_test()
 
 
@@ -625,10 +622,6 @@ class TarantoolServer(Server):
             try:
                 self.wait_until_started(wait_load)
             except TarantoolStartError:
-                # Raise exception when caller ask for it (e.g. in case of
-                # non-default servers)
-                if rais:
-                    raise
                 # Python tests expect we raise an exception when non-default
                 # server fails
                 if self.crash_expected:
@@ -641,6 +634,10 @@ class TarantoolServer(Server):
                                  'failed to start\n'.format(self),
                                  schema='error')
                     self.print_log(15)
+                # Raise exception when caller ask for it (e.g. in case of
+                # non-default servers)
+                if rais:
+                    raise
                 # if the server fails before any test started, we should inform
                 # a caller by the exception
                 if not self.current_test:


### PR DESCRIPTION
Show logs and only then reraise TarantoolStartError (see
TarantoolServer.start()).

Don't show logs on an instance that acquires to start an instance, e.g.
default one (see LuaTest.execute()).

How to reproduce using tarantool test suite:

 | diff --git a/test/box/proxy.lua b/test/box/proxy.lua
 | index fa87ab879..a90f24715 100644
 | --- a/test/box/proxy.lua
 | +++ b/test/box/proxy.lua
 | @@ -2,7 +2,7 @@
 |  os = require('os')

 |  box.cfg{
 | -    listen              = os.getenv("LISTEN"),
 | +    listen              = 3301,
 |      memtx_memory        = 107374182,
 |      pid_file            = "tarantool.pid",
 |      rows_per_wal        = 50

Hold 3301 port. Say, using tarantool:

 | ./src/tarantool <<< 'box.cfg{listen = 3301}' &

Run a test that performs default server restarting:

 | cd test && ./test-run.py --conf memtx engine/snapshot.test.lua

Fixes #159.