### PR TITLE
Fix false positive internal error detection

### DIFF
--- a/test-run.py
+++ b/test-run.py
@@ -107,7 +107,8 @@ def main_loop_parallel():
         dispatcher.wait_processes()
         color_stdout('-' * 81, "\n", schema='separator')
         has_failed = dispatcher.statistics.print_statistics()
-        has_undone = dispatcher.report_undone(verbose=True)
+        has_undone = dispatcher.report_undone(
+            verbose=bool(is_force or not has_failed))
         if has_failed:
             return EXIT_FAILED_TEST
         if has_undone:
@@ -120,7 +121,7 @@ def main_loop_parallel():
     except HangError:
         color_stdout('-' * 81, "\n", schema='separator')
         dispatcher.statistics.print_statistics()
-        dispatcher.report_undone(verbose=True)
+        dispatcher.report_undone(verbose=False)
         return EXIT_HANG
     return EXIT_SUCCESS
 


### PR DESCRIPTION
Tests are dispatched to task queue dispatchers at start and so it is
normal that tests can be not consumed when a test fails in non-force
mode or when a test hung. It is not test-run error.

The problem part with a failed (not hung) test was introduced in
d8abc031a6de3603b94660d66872f0485b5910cc ('Fail testing when test-run
fails internally').

Reported in
https://github.com/tarantool/test-run/issues/159#issuecomment-488065589