### PR TITLE
pretest_clean: add decimal to standard packages

### DIFF
--- a/pretest_clean.lua
+++ b/pretest_clean.lua
@@ -160,6 +160,7 @@ local function clean()
         crypto = true,
         csv = true,
         debug = true,
+        decimal = true,
         digest = true,
         errno = true,
         ffi = true,


### PR DESCRIPTION
We'll add decimal built-in module in the scope of
https://github.com/tarantool/tarantool/issues/692