### PR TITLE
Implement SQL driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Field `core` must be one of:
 
 ### Test
 
-Each test consists of files `*.test(.lua|.py)?`, `*.result`, and may have skip
-condition file `*.skipcond`.  On first run (without `.result`) `.result` is
-generated from output.  Each run, in the beggining, `.skipcond` file is
+Each test consists of files `*.test(.lua|.sql|.py)?`, `*.result`, and may have
+skip condition file `*.skipcond`.  On first run (without `.result`) `.result`
+is generated from output.  Each run, in the beggining, `.skipcond` file is
 executed. In the local env there's object `self`, that's `Test` object. If test
 must be skipped - you must put `self.skip = 1` in this file. Next,
 `.test(.lua|.py)?` is executed and file `.reject` is created, then `.reject` is
@@ -67,6 +67,11 @@ engine = test_run:get_cfg('engine')
 -- first run engine is 'memtx'
 -- second run engine is 'sophia'
 ```
+
+"engine" value has a special meaning for *.test.sql files: if it is "memtx" or
+"vinyl", then the corresponding engine will be set using "pragma
+sql_default_engine='memtx|vinyl'" command before executing commands from a test
+file.
 
 #### Python
 
@@ -233,6 +238,21 @@ test
 - 'function: 0x40e533b8'
 ...
 ```
+
+It is possible to use backslash at and of a line to carry it.
+
+```lua
+function echo(...) \
+    return ...     \
+end
+```
+
+#### SQL
+
+*.test.sql files are just SQL statements written line-by-line.
+
+It is possible to mix SQL and Lua commands using `\set language lua` and `\set
+language sql` commands.
 
 ##### Interaction with the test environment
 

--- a/lib/test_suite.py
+++ b/lib/test_suite.py
@@ -174,6 +174,7 @@ class TestSuite:
         inspector.start()
         # fixme: remove this string if we fix all legacy tests
         suite_name = os.path.basename(self.suite_path)
+        # Set 'lua' type for *.test.lua and *.test.sql test files.
         server.tests_type = 'python' if suite_name.endswith('-py') else 'lua'
         server.deploy(silent=False)
         return inspector

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -252,3 +252,9 @@ def print_unidiff(filepath_a, filepath_b):
                                 time_a,
                                 time_b)
     color_stdout.writeout_unidiff(diff)
+
+
+def prefix_each_line(prefix, data):
+    data = data.rstrip('\n')
+    lines = [(line + '\n') for line in data.split('\n')]
+    return prefix + prefix.join(lines)

--- a/listeners.py
+++ b/listeners.py
@@ -10,6 +10,7 @@ from lib.worker import WorkerDone
 from lib.worker import WorkerOutput
 from lib.worker import WorkerTaskResult
 from lib.worker import get_reproduce_file
+from lib.utils import prefix_each_line
 
 
 class BaseWatcher(object):
@@ -116,10 +117,7 @@ class OutputWatcher(BaseWatcher):
     def add_prefix(output, worker_id):
         prefix_max_len = len('[xxx] ')
         prefix = ('[%03d] ' % worker_id).ljust(prefix_max_len)
-        output = output.rstrip('\n')
-        lines = [(line + '\n') for line in output.split('\n')]
-        output = prefix + prefix.join(lines)
-        return output
+        return prefix_each_line(prefix, output)
 
     @staticmethod
     def _write(output, worker_id):


### PR DESCRIPTION
Actually three features are introduced with this commit.

## SQL driver

Now test-run recognizes *.test.sql files.

The content of those files are SQL statements written line-by-line. A
long statement may be splitted, see the next section.

The implementation leans on '\set language [lua|sql]' command of
tarantool console: appropriate language is set depending of a file name:
*.test.lua or *.test.sql before executing commands for a test file.

A value of 'engine' option when it is provided by a configuration has a
special meaning for *.test.sql tests (a configuration is a file set by
'config' option in suite.ini) . If it is 'memtx' or 'vinyl', then
corresponding default engine will be set for SQL subsystem before
executing commands for a test file. The implementation uses "pragma
sql_default_engine='memtx|vinyl'" command.

It is possible to mix Lua and SQL code in *.test.lua and *.test.sql
tests. Consider an example:

```
-- Verify output of large integers.
CREATE TABLE test (id INTEGER PRIMARY KEY)
INSERT INTO test VALUES (9223372036854775807)
SELECT * FROM test
\set language lua
box.space.TEST:select()
\set language sql
DROP TABLE test
```

## Line carrying with backslash

Consider the following code:

```
test_run:cmd("setopt delimiter ';'")
function echo(...)
    return ...
end
test_run:cmd("setopt delimiter ''");
```

Now it may be rewritten in the following way:

```
function echo(...) \
    return ...     \
end
```

This ability also works in SQL test files: a long statement may be
written in this way:

```
CREATE TABLE t1 (s1 VARCHAR(10) PRIMARY KEY)
CREATE TABLE t2 (s1 VARCHAR(10) PRIMARY KEY, s2 VARCHAR(10) \
    REFERENCES t1 ON DELETE CASCADE)
```

## New result file format

A new result file format is introduced. The differences are following.

1. A result of a Lua command or SQL statement is indented to easier
   distinguish from a command / statement itself.

Before:

```
CREATE TABLE t1 (s1 VARCHAR(10) PRIMARY KEY)
---
- row_count: 1
...
```

After:

```
CREATE TABLE t1 (s1 VARCHAR(10) PRIMARY KEY)
 | ---
 | - row_count: 1
 | ...
```

2. Empty lines from a test file are preserved in a result file.

3. A small bug when a comment in a setopt-delimiter block is written
   before a previous command was fixed.

4. The first line of a result file in the new format is a version line.

```
-- test-run result file version 2
```

A result file for a new test will be written in the new format, but when
a result file already exists (and has the old format), test-run performs
formatting of a test output in the old way. So the new test-run version
is backward compatible with previous ones and no changes are needed for
existing test and result files.

If you want to update a result file to the new format, remove it and run
a test.

If you want to produce a result file in the old format for a new test,
create an empty result file, run a test and move *.reject to *.result.

Fixes https://github.com/tarantool/tarantool/issues/4123