### PR TITLE
pretest_clean: clean strict module state

### DIFF
--- a/pretest_clean.lua
+++ b/pretest_clean.lua
@@ -144,6 +144,14 @@ local function clean()
     end
     cleanup_list(_G, allowed_globals)
 
+    -- Strict module tracks declared global variables when the
+    -- strict mode is enabled, so we need to flush its internal
+    -- state.
+    local mt = getmetatable(_G)
+    if mt ~= nil and type(mt.__declared) == 'table' then
+        cleanup_list(mt.__declared, allowed_globals)
+    end
+
     local allowed_packages = {
         ['_G'] = true,
         bit = true,


### PR DESCRIPTION
app/strict.test.lua expects that 'a' variable is not declared at the
start of the test. However if the strict mode is enabled (which is
default in a debug build) global variables assignments are tracked
inside a metatable of _G. A variable is considered declared even if it
is set to `nil`.

If a test that runs before app/strict.test.lua set 'a' to any value,
then app/strict.test.lua will fail.

So we need to clean the metatable of _G in addition to _G itself.