### PR TITLE
Don't check whether yaml responses are well-formed

### DIFF
--- a/lib/admin_connection.py
+++ b/lib/admin_connection.py
@@ -24,8 +24,6 @@ __author__ = "Konstantin Osipov <kostja.osipov@gmail.com>"
 import re
 import sys
 
-import yaml
-
 from tarantool_connection import TarantoolConnection
 from tarantool_connection import TarantoolPool
 from tarantool_connection import TarantoolAsyncConnection
@@ -75,11 +73,8 @@ class ExecMixIn(object):
             if (res.rfind("\n...\n") >= 0 or res.rfind("\r\n...\r\n") >= 0):
                 break
 
-        try:
-            yaml.safe_load(res)
-        finally:
-            if not silent:
-                sys.stdout.write(res.replace("\r\n", "\n"))
+        if not silent:
+            sys.stdout.write(res.replace("\r\n", "\n"))
         return res
 
 


### PR DESCRIPTION
pyyaml is unable to parse complex dictionary keys: say, a list or a
dictionary. See https://github.com/yaml/pyyaml/issues/88

Tarantool however supports this kind of output:

```
tarantool> {[{k = 'v'}] = 1}
---
- ? k: v
  : 1
...
```

When such response is arrived to test-run, pyyaml raises 'found
unhashable key' exception and test-run reports it as '[Lost current
connection]'.

Let's consider 'core = tarantool' tests. There is no much need to verify
whether a tarantool answer is well-formed yaml document, because it
anyway will be verified against a result file. And also it is unable to
handle the case above. So the check is removed.

See https://github.com/tarantool/tarantool/issues/4421