### PR TITLE
Add the 'timeout' option into 'stop server' command and kill a server…

### DIFF
--- a/lib/colorer.py
+++ b/lib/colorer.py
@@ -20,6 +20,33 @@ def color_log(*args, **kwargs):
     color_stdout(*args, **kwargs)
 
 
+def qa_notice(*args, **kwargs):
+    """ Print a notice for an QA engineer at the terminal.
+
+        Example::
+
+            * [QA Notice]
+            *
+            * Attempt to stop already stopped server 'foo'
+            *
+    """
+    # Import from the function to avoid recursive import.
+    from lib.utils import prefix_each_line
+
+    # Use 'info' color by default (yellow).
+    if 'schema' not in kwargs:
+        kwargs = dict(kwargs, schema='info')
+
+    # Join all positional arguments (like color_stdout() do) and
+    # decorate with a header and asterisks.
+    data = ''.join([str(msg) for msg in args])
+    data = prefix_each_line('* ', data)
+    data = '\n* [QA Notice]\n*\n{}*\n'.format(data)
+
+    # Write out.
+    color_stdout(data, **kwargs)
+
+
 class CSchema(object):
     objects = {}
 

--- a/lib/inspector.py
+++ b/lib/inspector.py
@@ -10,6 +10,7 @@ from lib.utils import find_port
 from lib.utils import prefix_each_line
 from lib.colorer import color_stdout
 from lib.colorer import color_log
+from lib.colorer import qa_notice
 
 from lib.tarantool_server import TarantoolStartError
 from lib.preprocessor import LuaPreprocessorException
@@ -102,8 +103,7 @@ class TarantoolInspector(StreamServer):
                 # propagate to the main greenlet
                 raise
             except LuaPreprocessorException as e:
-                color_stdout('\n* [QA Notice]\n*\n* {0}\n*\n'.format(str(e)),
-                             schema='info')
+                qa_notice(str(e))
                 result = {'error': str(e)}
             except Exception as e:
                 self.parser.kill_current_test()

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -15,6 +15,7 @@ import yaml
 
 from gevent import socket
 from greenlet import GreenletExit
+from threading import Timer
 
 try:
     from cStringIO import StringIO
@@ -23,7 +24,9 @@ except ImportError:
 
 from lib.admin_connection import AdminConnection, AdminAsyncConnection
 from lib.box_connection import BoxConnection
-from lib.colorer import color_stdout, color_log
+from lib.colorer import color_stdout
+from lib.colorer import color_log
+from lib.colorer import qa_notice
 from lib.preprocessor import TestState
 from lib.server import Server
 from lib.test import Test
@@ -984,9 +987,26 @@ class TarantoolServer(Server):
                 self.process.send_signal(signal)
             except OSError:
                 pass
+
+            # Waiting for stopping the server. If the timeout
+            # reached, send SIGKILL.
+            timeout = 5
+
+            def kill():
+                qa_notice('The server \'{}\' does not stop during {} '
+                          'seconds after the {} ({}) signal.\n'
+                          'Info: {}\n'
+                          'Sending SIGKILL...'.format(
+                              self.name, timeout, signal, signame(signal),
+                              format_process(self.process.pid)))
+                self.process.kill()
+
+            timer = Timer(timeout, kill)
+            timer.start()
             if self.crash_detector is not None:
                 save_join(self.crash_detector)
             self.wait_stop()
+            timer.cancel()
 
         self.status = None
         if re.search(r'^/', str(self._admin.port)):


### PR DESCRIPTION
… with

 'SIGKILL' if it doesn't finished before timeout is expired..

By default drop_cluster() routine uses SIGTERM signal to stop the
replications. Found that in some situations SIGTERM couldn't kill
all instances on OSX and some processes left. To avoid of such
situations need additionally to send SIGKILL signal to all instances
that were not finished before timeout was expired to be able to stop
them all.