### PR TITLE
Postpone fragile tests

### DIFF
--- a/dispatcher.py
+++ b/dispatcher.py
@@ -56,8 +56,10 @@ class Dispatcher:
     ```
     task_groups = {
         'some_key_1': {
-            'gen_worker': gen_worker_1,
-            'task_ids': task_ids_1,
+            'gen_worker': function,
+            'task_ids': list,
+            'is_parallel': bool,
+            'show_reproduce_content': bool,
         }
         ...
     }

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -197,6 +197,10 @@ class Dispatcher:
         task_queue_disp = self.find_nonempty_task_queue_disp()
         if not task_queue_disp:
             return False
+        # self.max_workers_cnt can be changed in
+        # find_nonempty_task_queue_disp()
+        if self.workers_cnt >= self.max_workers_cnt:
+            return False
         tcp_port_range = self.tcp_port_dispatcher.acquire_range(
             self.worker_next_id)
         process = task_queue_disp.add_worker(self.worker_next_id,


### PR DESCRIPTION
Added "fragile" option with a list of tests that are not intended to be run in parallel with others. The format of the list is the same as for "disabled" option.