### PR TITLE
Relax gevent version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==5.1
 argparse==1.1
 msgpack-python==0.4.6
-gevent==1.1b5
+gevent>=1.1b5,<2
 six>=1.8.0


### PR DESCRIPTION
test-run works on a wide range of gevent versions (thanks to its stable
API), so gevent version is not matter much for us. However more recent
versions usually have built wheels on PyPI for wider range of Python
versions. It may be convenient for a pip user: (s)he doesn't need to
install a package with python headers to compile gevent module.

PEP 440 provides different ways to hold a major version of a package.
Three lines below are equivalent:

 | gevent>=1,<2
 | gevent~=1
 | gevent==1.*

However some ancient pip versions supports only the first syntax, see
[1]. Don't sure whether they are actually used anywhere, but use the old
syntax just in case.

[1]: https://github.com/pypa/pip/issues/2737