### PR TITLE
Add --exclude option

### DIFF
--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -140,6 +140,7 @@ class AppServer(Server):
         test_suite.ini['suite'] = suite_path
 
         test_names = sorted(glob.glob(os.path.join(suite_path, "*.test.lua")))
+        test_names = Server.exclude_tests(test_names, test_suite.args.exclude)
         test_names = sum(map((lambda x: patterned(x, test_suite.args.tests)),
                              test_names), [])
         tests = []

--- a/lib/options.py
+++ b/lib/options.py
@@ -50,6 +50,15 @@ class Options:
                 tests in all specified suites.""")
 
         parser.add_argument(
+                "--exclude",
+                action='append',
+                default=env_list('TEST_RUN_EXCLUDE', []),
+                help="""Set an exclusion pattern. When a full test name (say,
+                app-tap/string.test.lua) contains the pattern as a substring,
+                the test will be excluded from execution. The option can be
+                passed several times.""")
+
+        parser.add_argument(
                 "--suite",
                 dest='suites',
                 metavar="suite",
@@ -192,6 +201,9 @@ class Options:
                 help="""Run the server under 'luacov'.
                 Default: false.""")
 
+        # XXX: We can use parser.parse_intermixed_args() on
+        # Python 3.7 to understand commands like
+        # ./test-run.py foo --exclude bar baz
         self.args = parser.parse_args()
         self.check()
 

--- a/lib/server.py
+++ b/lib/server.py
@@ -135,3 +135,17 @@ class Server(object):
             print_tail_n(self.logfile, lines)
         else:
             color_stdout("    Can't find log:\n", schema='error')
+
+    @staticmethod
+    def exclude_tests(test_names, exclude_patterns):
+        def match_any(test_name, patterns):
+            for pattern in patterns:
+                if pattern in test_name:
+                    return True
+            return False
+
+        res = []
+        for test_name in test_names:
+            if not match_any(test_name, exclude_patterns):
+                res.append(test_name)
+        return res

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -1075,7 +1075,7 @@ class TarantoolServer(Server):
             for pattern in patterns:
                 path_pattern = os.path.join(suite_path, pattern)
                 res.extend(sorted(glob.glob(path_pattern)))
-            return res
+            return Server.exclude_tests(res, test_suite.args.exclude)
 
         # Add Python tests.
         tests = [PythonTest(k, test_suite.args, test_suite.ini)

--- a/lib/unittest_server.py
+++ b/lib/unittest_server.py
@@ -75,6 +75,8 @@ class UnittestServer(Server):
             executable_path_glob = os.path.join(test_suite.args.builddir,
                                                 'test', suite_path, '*.test')
             tests = glob.glob(executable_path_glob)
+
+        tests = Server.exclude_tests(tests, test_suite.args.exclude)
         test_suite.tests = [UnitTest(k, test_suite.args, test_suite.ini)
                             for k in sorted(tests)]
         test_suite.tests = sum([patterned(x, test_suite.args.tests)


### PR DESCRIPTION
The option allows to avoid execution of a certain subset of tests.

The option sets a pattern for exclusion and all tests are filtered using
it: if a full test name (say, app-tap/string.test.lua) contains the
pattern as a substring, then the test will be excluded from execution.

The option can be passed several times to set several exclusions
patterns.

A list of such exclusion patterns also can be provided using
TEST_RUN_EXCLUDE environment variable (patterns are separated by
whitespaces).

If both the environment variable and the option are provided, then the
environment variable value will be ignored.

Trick: `--exclude foo/` allows to exclude a test suite.

Fixes #54.