### PR TITLE
pretest_clean: add popen built-in module

### DIFF
--- a/pretest_clean.lua
+++ b/pretest_clean.lua
@@ -271,6 +271,7 @@ local function clean()
         os = true,
         package = true,
         pickle = true,
+        popen = true,
         pwd = true,
         socket = true,
         strict = true,


### PR DESCRIPTION
We're going to implement it in the scope of
https://github.com/tarantool/tarantool/issues/4031