### PR TITLE
prepare test-run for out of source build

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ executed. In the local env there's object `self`, that's `Test` object. If test
 must be skipped - you must put `self.skip = 1` in this file. Next,
 `.test(.lua|.py)?` is executed and file `.reject` is created, then `.reject` is
 compared with `.result`. If something differs, then 15 last string of this diff
-file are printed and `.reject` file is saving in the folder, where `.result`
-file is. If not, then `.reject` is deleted.
+file are printed and `.reject` file is saving in the `<vardir>/rejects/<suite>`
+subfolder given in options or set localy as `var/rejects/<suite>` by default.
+If not, then `.reject` file is deleted.
 
 ### Test configuration
 

--- a/lib/test.py
+++ b/lib/test.py
@@ -9,6 +9,7 @@ import sys
 import traceback
 from functools import partial
 from hashlib import md5
+from utils import safe_makedirs
 
 try:
     from cStringIO import StringIO
@@ -114,7 +115,9 @@ class Test(object):
         self.result = os.path.join(suite_ini['suite'], get_result(name))
         self.skip_cond = os.path.join(suite_ini['suite'], get_skipcond(name))
         self.tmp_result = os.path.join(suite_ini['vardir'], get_result(name))
-        self.reject = os.path.join(suite_ini['suite'], get_reject(name))
+        self.var_suite_path = os.path.join(suite_ini['vardir'], 'rejects',
+                                           suite_ini['suite'])
+        self.reject = os.path.join(self.var_suite_path, get_reject(name))
         self.is_executed = False
         self.is_executed_ok = None
         self.is_equal_result = None
@@ -253,6 +256,7 @@ class Test(object):
         else:
             has_result = os.path.exists(self.tmp_result)
             if has_result:
+                safe_makedirs(self.var_suite_path)
                 shutil.copy(self.tmp_result, self.reject)
                 with open(self.tmp_result, mode='rb') as result_file:
                     result_checksum = md5(result_file.read()).hexdigest()


### PR DESCRIPTION
Changed the path for saving *.reject files, for now it is saving in
the `<vardir>/<suite>` subfolder given in options or set localy as
`var/<suite>` by default.
