### PR TITLE
Fix 'use_unix_sockets_iproto' for 'core = app'

### DIFF
--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -19,6 +19,7 @@ from test import TestRunGreenlet, TestExecutionError
 
 
 def run_server(execs, cwd, server, logfile, retval):
+    os.putenv("LISTEN", server.iproto)
     server.process = Popen(execs, stdout=PIPE, stderr=PIPE, cwd=cwd)
     stdout, stderr = server.process.communicate()
     sys.stdout.write(stdout)
@@ -108,9 +109,9 @@ class AppServer(Server):
         if self.use_unix_sockets_iproto:
             path = os.path.join(self.vardir, self.name + ".socket-iproto")
             warn_unix_socket(path)
-            os.putenv("LISTEN", path)
+            self.iproto = path
         else:
-            os.putenv("LISTEN", str(find_port()))
+            self.iproto = str(find_port())
         shutil.copy(os.path.join(self.TEST_RUN_DIR, 'test_run.lua'),
                     self.vardir)
 


### PR DESCRIPTION
'core = app' test (as well as 'core = tarantool' one) may start more
servers within a test using the following commands:

```lua
local test_run = require('test_run').new()
test_run:cmd("create server foo with script='foo.lua'")
test_run:cmd("start server foo")
```

AppServer sets LISTEN environment variable for its child processes. New
servers, which are started from a test, do the same within the same 
test-run worker process (at 'create server <...>' command) and so they
rewrote the environment variable.

Usually everything works even despite unexpexted iproto socket name, but
let's consider the following case:

```lua
-- test1.test.lua
box.cfg({listen = os.getenv('LISTEN')})
-- test1 listening now on app_server.socket-iproto
test_run:cmd("create server foo with script='foo.lua'")
-- foo listening now on foo.socket-iproto
test_run:cmd("start server foo")
<...>
test_run:cmd("stop server foo")
test_run:cmd("cleanup server foo")
test_run:cmd("delete server foo")
```
 
```lua
-- test2.test.lua
box.cfg({listen = os.getenv('LISTEN')})
-- test2 listening now on foo.socket-iproto (!)
test_run:cmd("create server foo with script='foo.lua'")
-- foo want to use foo.socket-iproto for listening, but it is 
-- already taken
test_run:cmd("start server foo")
<...>
test_run:cmd("stop server foo")
test_run:cmd("cleanup server foo")
test_run:cmd("delete server foo")
```
 
The real example is shown in [1].

The fix is quite straightforward: store iproto port or path in a
variable and put it to environment just before spawn a new tarantool
process. 

[1]: https://github.com/tarantool/tarantool/issues/4459#issuecomment-628430495

Part of https://github.com/tarantool/tarantool/issues/4459