### PR TITLE
fix(writeout_unidiff): notify about missing newline

### DIFF
--- a/lib/colorer.py
+++ b/lib/colorer.py
@@ -221,6 +221,10 @@ class Colorer(object):
 
     def writeout_unidiff(self, diff):
         for i in diff:
+
+            if not i.endswith('\n'):
+                i += "\n\\ No newline\n"
+
             if i.startswith('+'):
                 self.write(i, schema='diff_in')
             elif i.startswith('-'):


### PR DESCRIPTION
Print 'diff'-like message about missing newline.
Previously if .result file was missing a newline the output would be the
following:

[047]  ---
[047] -...+...
[047]

After this patch:

[047]  ---
[047] -...
[047] \ No newline
[047] +...
[047]

Closes #212