### PR TITLE
Enable test reruns on failed fragiled tests

### DIFF
--- a/lib/test.py
+++ b/lib/test.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 import traceback
 from functools import partial
+from hashlib import md5
 
 try:
     from cStringIO import StringIO
@@ -152,9 +153,9 @@ class Test(object):
             it to stdout.
 
             Returns short status of the test as a string: 'skip', 'pass',
-            'new', 'updated' or 'fail'. There is also one possible value for
-            short_status, 'disabled', but it returned in the caller,
-            TestSuite.run_test().
+            'new', 'updated' or 'fail' and results file checksum on fail.
+            There is also one possible value for short_status, 'disabled',
+            but it returned in the caller, TestSuite.run_test().
         """
 
         # Note: test was created before certain worker become known, so we need
@@ -219,6 +220,7 @@ class Test(object):
             self.is_valgrind_clean = not bool(non_empty_logs)
 
         short_status = None
+        result_checksum = None
 
         if self.skip:
             short_status = 'skip'
@@ -252,6 +254,8 @@ class Test(object):
             has_result = os.path.exists(self.tmp_result)
             if has_result:
                 shutil.copy(self.tmp_result, self.reject)
+                with open(self.tmp_result, mode='rb') as result_file:
+                    result_checksum = md5(result_file.read()).hexdigest()
             short_status = 'fail'
             color_stdout("[ fail ]\n", schema='test_fail')
 
@@ -277,7 +281,7 @@ class Test(object):
                                            "Test failed! Output from log file "
                                            "{0}:\n".format(log_file))
                 where = ": there were warnings in the valgrind log file(s)"
-        return short_status
+        return short_status, result_checksum
 
     def print_diagnostics(self, log_file, message):
         """Print whole lines of client program output leading to test

--- a/lib/test_suite.py
+++ b/lib/test_suite.py
@@ -81,7 +81,7 @@ class TestSuite:
         self.args = args
         self.tests = []
         self.ini = {}
-        self.fragile = {'tests': {}}
+        self.fragile = {'retries': 0, 'tests': {}}
         self.suite_path = suite_path
         self.ini["core"] = "tarantool"
 
@@ -264,6 +264,9 @@ class TestSuite:
 
     def is_parallel(self):
         return self.ini['is_parallel']
+
+    def fragile_retries(self):
+        return self.fragile.get('retries', 0)
 
     def show_reproduce_content(self):
         return self.ini['show_reproduce_content']

--- a/listeners.py
+++ b/listeners.py
@@ -45,6 +45,7 @@ class StatisticsWatcher(BaseWatcher):
         if obj.short_status == 'fail':
             self.failed_tasks.append((obj.task_id,
                                       obj.worker_name,
+                                      obj.result_checksum,
                                       obj.show_reproduce_content))
 
     def print_statistics(self):
@@ -58,10 +59,11 @@ class StatisticsWatcher(BaseWatcher):
             return False
 
         color_stdout('Failed tasks:\n', schema='test_var')
-        for task_id, worker_name, show_reproduce_content in self.failed_tasks:
+        for task_id, worker_name, result_checksum, show_reproduce_content in self.failed_tasks:
             logfile = self.get_logfile(worker_name)
             task_id_str = yaml.safe_dump(task_id, default_flow_style=True)
             color_stdout('- %s' % task_id_str, schema='test_var')
+            color_stdout('# results file checksum: %s\n' % result_checksum)
             color_stdout('# logfile:        %s\n' % logfile)
             reproduce_file_path = get_reproduce_file(worker_name)
             color_stdout('# reproduce file: %s\n' % reproduce_file_path)


### PR DESCRIPTION
Added ability to use fragile list in JSON format from 'suite.ini'
files.
```
   fragile = {
        "retries": 10,
        "tests": {
            "bitset.test.lua": {
                "issues": [ "gh-4095" ],
                "checksums": [ "050af3a99561a724013995668a4bc71c", "f34be60193cfe9221d3fe50df657e9d3" ]
            }
        }}
```

Added ability to set per suite in suite.ini configuration file
'retries' option, which sets the number of accepted reruns of
the tests failed from 'fragile' list.

Added ability to check failed tests w/ fragile list to be sure that
the current fail equal to the issue mentioned in the fragile list.

Closes #189.