### PR TITLE
Collect results artifacts of the failed workers

### DIFF
--- a/dispatcher.py
+++ b/dispatcher.py
@@ -95,6 +95,7 @@ class Dispatcher:
         self.report_timeout = 1.0
 
         self.statistics = None
+        self.artifacts = None
         self.fail_watcher = None
         self.listeners = None
         self.init_listeners()
@@ -132,8 +133,10 @@ class Dispatcher:
         log_output_watcher = listeners.LogOutputWatcher()
         self.statistics = listeners.StatisticsWatcher(
             log_output_watcher.get_logfile)
+        self.artifacts = listeners.ArtifactsWatcher(
+            log_output_watcher.get_logfile)
         output_watcher = listeners.OutputWatcher()
-        self.listeners = [self.statistics, log_output_watcher, output_watcher]
+        self.listeners = [self.statistics, log_output_watcher, output_watcher, self.artifacts]
         if watch_fail:
             self.fail_watcher = listeners.FailWatcher(
                 self.terminate_all_workers)

--- a/test-run.py
+++ b/test-run.py
@@ -110,6 +110,7 @@ def main_loop_parallel():
         has_undone = dispatcher.report_undone(
             verbose=bool(is_force or not has_failed))
         if has_failed:
+            dispatcher.artifacts.save_artifacts()
             return EXIT_FAILED_TEST
         if has_undone:
             return EXIT_NOTDONE_TEST


### PR DESCRIPTION
ArtifactsWatcher listener collects list of all workers with failed
tests. After overall testing finishes it copies workers artifacts
files from its running 'vardir' sub-directories to the common path
'<vardir>/artifacts' to be able to collect these artifacts later.

    
Closes #90