### PR TITLE
Pass on space drop fail

### DIFF
--- a/pretest_clean.lua
+++ b/pretest_clean.lua
@@ -27,7 +27,9 @@ local function clean()
         local first_char = string.sub(name, 1, 1)
         return first_char ~= '_'
     end):each(function(name)
-        box.space[name]:drop()
+        if box.space[name] ~= nil then
+            box.space[name]:drop()
+        end
     end)
 
     local _USER_TYPE = 4


### PR DESCRIPTION
Found issue:
```
      [026] --- box/update.result   Thu Aug 13 01:06:17 2020
      [026] +++ box/update.reject   Tue Aug 18 01:31:24 2020
      [026] @@ -1,2130 +1,3 @@
      [026] -s = box.schema.space.create('tweedledum')
      [026]  ---
      [026] +- error: '/private/tmp/tnt/026_box/pretest_clean.lua:30: attempt to index a nil value'
      [026]  ...
      [026] -index = s:create_index('pk')
```
Issue happened in additional tool pretest_clean.lua which is used for
cleanning up the environment before running the test. Fail occurred
when space to be deleted was not found, like:
```
      tarantool> name = "BAD_SPACE_NAME" box.space[name]:drop()
      ---
      - error: '[string "name = "BAD_SPACE_NAME" box.space[name]..."]:1: attempt to
          index a nil value'
      ...
```
It could happen because their is some delay between getting the list of
spaces and the moment when these spaces are removing, check the failing
function from pretest_clean.sh file:
```
      box.space._space:pairs():map(function(tuple)
            local name = tuple[3]
            return name
        end):filter(function(name)
            -- skip internal spaces
            local first_char = string.sub(name, 1, 1)
            return first_char ~= '_'
        end):each(function(name)
            box.space[name]:drop()
        end)
```
In this delay the space could be already removed with information about
it. In this way getting the space with wrong name returned nil and drop
routine failed on it. To avoid of it the existence of the space should
be rechecked just before the call to its drop:

```
      box.space._space:pairs():map(function(tuple)
            local name = tuple[3]
            return name
        end):filter(function(name)
            -- skip internal spaces
            local first_char = string.sub(name, 1, 1)
            return first_char ~= '_'
        end):each(function(name)
            if box.space[name] ~= nil then box.space[name]:drop() end
        end)
```
Closes tarantool/tarantool#5247
