### PR TITLE
Fix reproduce file formatting (use flow style)

### DIFF
--- a/dispatcher.py
+++ b/dispatcher.py
@@ -255,7 +255,8 @@ class Dispatcher:
                 'queue, but were not reported as done (does not matters '
                 'success or fail):\n', schema='test_var')
             for task_id in undone:
-                color_stdout('- %s' % yaml.safe_dump(task_id))
+                task_id_str = yaml.safe_dump(task_id, default_flow_style=True)
+                color_stdout('- %s' % task_id_str)
         else:
             # Visually continue StatisticsWatcher.print_statistics() output.
             color_stdout('* undone: %d\n' % len(undone), schema='test_var')

--- a/lib/worker.py
+++ b/lib/worker.py
@@ -300,7 +300,8 @@ class Worker:
         try:
             task = self.find_task(task_id)
             with open(self.reproduce_file, 'a') as f:
-                f.write('- ' + yaml.safe_dump(task.id))
+                task_id_str = yaml.safe_dump(task.id, default_flow_style=True)
+                f.write('- ' + task_id_str)
             short_status = self.suite.run_test(
                 task, self.server, self.inspector)
         except KeyboardInterrupt:

--- a/listeners.py
+++ b/listeners.py
@@ -60,7 +60,8 @@ class StatisticsWatcher(BaseWatcher):
         color_stdout('Failed tasks:\n', schema='test_var')
         for task_id, worker_name, show_reproduce_content in self.failed_tasks:
             logfile = self.get_logfile(worker_name)
-            color_stdout('- %s' % yaml.safe_dump(task_id), schema='test_var')
+            task_id_str = yaml.safe_dump(task_id, default_flow_style=True)
+            color_stdout('- %s' % task_id_str, schema='test_var')
             color_stdout('# logfile:        %s\n' % logfile)
             reproduce_file_path = get_reproduce_file(worker_name)
             color_stdout('# reproduce file: %s\n' % reproduce_file_path)


### PR DESCRIPTION
Set flow style (JSON-like) explicitly instead of block style to don't
break indentation.

Before the patch (incorrect):

```yaml
- - app-tap/iconv.test.lua
- null
```

After the patch:

```yaml
- [app-tap/iconv.test.lua, null]
```

The default was changed in [1].

[1]: https://github.com/yaml/pyyaml/pull/256