### PR TITLE
Add box_snapshot wrapper

### DIFF
--- a/test_run.lua
+++ b/test_run.lua
@@ -437,6 +437,17 @@ local function wait_log(self, node, what, bytes, timeout, opts)
     return wait_cond(self, cond, timeout, delay)
 end
 
+-- Helper for box.snapshot to save changing data in log file instead of
+-- saving in results file, to be able to collect results file checksum
+-- for rerun ability.
+local function box_snapshot()
+    local ok, res = pcall(box.snapshot)
+    if not ok then
+        log.error("box.snapshot() failed with error: " .. res)
+    end
+    return ok
+end
+
 local inspector_methods = {
     cmd = cmd,
     eval = eval,
@@ -464,6 +475,7 @@ local inspector_methods = {
     grep_log = grep_log,
     wait_cond = wait_cond,
     wait_log = wait_log,
+    box_snapshot = box_snapshot,
 }
 
 local function inspector_new(host, port)


### PR DESCRIPTION
Found the issue with collecting results file checksum failing on
box.snapshot calls. In results file it returned changing data, like:

[076] --- vinyl/snapshot.result	Thu Oct 22 09:46:53 2020
[076] +++ vinyl/snapshot.reject	Thu Oct 22 19:35:41 2020
[076] @@ -128,7 +128,7 @@
[076]  ...
[076]  box.snapshot()
[076]  ---
[076] -- ok
[076] +- error: 'Invalid VYLOG file: Slice 1664 deleted but not registered'
[076]  ...
[076]  s:select({99}, {iterator = box.index.LE, limit = 10})
[076]  ---
[076]

Where slice number always different. To be able to collect results file
checksum for rerun ability added helper box_snapshot for box.snapshot
to save changing data in log file instead of saving it in results file.