### PR TITLE
Fix server_stop() routine on broken connections

### DIFF
--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -215,8 +215,11 @@ class TestState(object):
         if sname not in self.servers:
             raise LuaPreprocessorException(
                 'Can\'t stop nonexistent server {0}'.format(repr(sname)))
-        self.connections[sname].disconnect()
-        self.connections.pop(sname)
+        try:
+            self.connections[sname].disconnect()
+            self.connections.pop(sname)
+        except KeyError:
+            pass
         if 'signal' in opts:
             # convert to an integer if a number is passed, leave a string
             # otherwise


### PR DESCRIPTION
    Running the testing job:

      https://gitlab.com/tarantool/tarantool/-/jobs/825715179#L5349

    found the issue with server_stop() routine when connection was already
    closed, it broke test-run process and left replications running
    processes:

      1. Broken test-run:   

        [162] replication/election_qsync_stress.test.lua      memtx
        [162] TarantoolInpector.handle() received the following error:
        [162] Traceback (most recent call last):
        [162]   File "/builds/nZUxDh2c/0/tarantool/tarantool/test-run/lib/inspector.py", line 94, in handle
        [162]     result = self.parser.parse_preprocessor(line)
        [162]   File "/builds/nZUxDh2c/0/tarantool/tarantool/test-run/lib/preprocessor.py", line 106, in parse_preprocessor
        [162]     return self.server(stype, sname, options)
        [162]   File "/builds/nZUxDh2c/0/tarantool/tarantool/test-run/lib/preprocessor.py", line 345, in server
        [162]     return getattr(self, attr)(ctype, sname, opts)
        [162]   File "/builds/nZUxDh2c/0/tarantool/tarantool/test-run/lib/preprocessor.py", line 225, in server_stop
        [162]     self.connections[sname].disconnect()
        [162] KeyError: 'election_replica2'
        [162] [ fail ]

      2. Failed test:

        [162] --- replication/election_qsync_stress.result  Mon Nov  2 14:21:24 2020
        [162] +++ var/rejects/replication/election_qsync_stress.reject      Mon Nov 2 19:10:41 2020
        [162] @@ -102,6 +102,7 @@
        [162]      old_leader = new_leader
        [162]  end;
        [162]   | ---
        [162] + | - error: Found uncommitted sync transactions from other instance with id 1
        [162]   | ...
        [162]  test_run:cmd('setopt delimiter ""');
        [162]   | ---
        [162] @@ -110,9 +111,7 @@
        [162]  -- We're connected to some leader.
        [162]  #c.space.test:select{} == 10 or require('log').error(c.space.test:select{})
        [162]   | ---
        [162] - | - true
        [162] + | - null
        [162]   | ...
        [162]
        [162]  test_run:drop_cluster(SERVERS)
        [162] - | ---
        [162] - | ...
        [162]

    To avoid of the issue exception on missed connection should be checked
    and to be sure that drop_cluster() routine would have the chance to
    stop the replication process this exception should be passed.
