### PR TITLE
Wait replica respond before load it in safe_load()

### DIFF
--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -400,9 +400,11 @@ class TestState(object):
                                            'the nonexistent server {0}'.format(
                                             repr(name)))
         self.servers[name].admin.reconnect()
-        result = self.servers[name].admin(
-            '%s%s' % (expr, self.delimiter), silent=silent
-        )
+        result = None
+        while not result:
+            result = self.servers[name].admin(
+                '%s%s' % (expr, self.delimiter), silent=silent
+            )
         result = yaml.safe_load(result)
         if not result:
             result = []


### PR DESCRIPTION
    Check data exists before load in safe_load()
    
    lua_eval() routine is used for evaluating lua command on a given
    instance. Before run the command it reconnects to the needed instance
    and runs it there. After the command run safe_load() is called to parse
    the result. Found that some times safe_load() routine may fail with
    AttributeError internal exception. It happens, because result value
    from running command on the instance was not checked that it was not
    empty. To fix it was added waiting loop for replica respond before
    load it in safe_load() routine.
    
    Check the following output from gitlab-ci job [1]:
```
      DEBUG: sending command: test_run:wait_fullmesh(SERVERS)
      DEBUG: test-run received command: config engine
      DEBUG: test-run's response for [config engine]
       | !!python/unicode 'engine': !!python/unicode 'memtx'
       | ...
      DEBUG: test-run received command: eval autobootstrap1 "return box.info.server"
      DEBUG: test-run's response for [eval autobootstrap1 "return box.info.server"]
       | - id: null
       |   lsn: -1
       |   ro: true
       |   uuid: e84d86bd-d2fc-43c1-b832-8146d1f02cd1
       | ...
      DEBUG: test-run received command: eval autobootstrap1 "return box.info.server"
      DEBUG: test-run's response for [eval autobootstrap1 "return box.info.server"]
       | - id: null
       |   lsn: -1
       |   ro: true
       |   uuid: e84d86bd-d2fc-43c1-b832-8146d1f02cd1
       | ...
      DEBUG: test-run received command: eval autobootstrap1 "return box.info.server"
    
      TarantoolInpector.handle() received the following error:
      Traceback (most recent call last):
        File "test-run/lib/inspector.py", line 100, in handle
          result = self.parser.parse_preprocessor(line)
        File "test-run/lib/preprocessor.py", line 87, in parse_preprocessor
          return self.lua_eval(name, expr[1:-1])
        File "test-run/lib/preprocessor.py", line 404, in lua_eval
          result = yaml.safe_load(result)
        File "/usr/local/lib/python2.7/site-packages/yaml/__init__.py", line 162, in safe_load
          return load(stream, SafeLoader)
        File "/usr/local/lib/python2.7/site-packages/yaml/__init__.py", line 112, in load
          loader = Loader(stream)
        File "/usr/local/lib/python2.7/site-packages/yaml/loader.py", line 34, in __init__
          Reader.__init__(self, stream)
        File "/usr/local/lib/python2.7/site-packages/yaml/reader.py", line 87, in __init__
          self.determine_encoding()
        File "/usr/local/lib/python2.7/site-packages/yaml/reader.py", line 126, in determine_encoding
          self.update_raw()
        File "/usr/local/lib/python2.7/site-packages/yaml/reader.py", line 183, in update_raw
          data = self.stream.read(size)
      AttributeError: 'NoneType' object has no attribute 'read'
      DEBUG: test-run's response for [eval autobootstrap1 "return box.info.server"]
       | error: AttributeError("'NoneType' object has no attribute 'read'",)
       | ...
      Kill all servers ...
    
      [Instance "autobootstrap1" returns with non-zero exit code: 1]
```
    It is seen here that wait_fullmesh() routine waits for the server in
    loop and after successfull 2 checks it fails on the 3rd one.
    
after fix it works like this [2] (file: log/096_replication.log, line: 29111):
```
[2020-11-30 13:02:56.799806] DEBUG: test-run received command: eval replica_uuid_ro1 "return box.info.server"
[2020-11-30 13:02:56.802305] DEBUG: test-run's response for [eval replica_uuid_ro1 "return box.info.server"]
[2020-11-30 13:02:56.802305]  | - id: 1
[2020-11-30 13:02:56.802305]  |   lsn: 8
[2020-11-30 13:02:56.802305]  |   ro: false
[2020-11-30 13:02:56.802305]  |   uuid: 9cdee878-98e1-4a6f-af4d-fd19d999aa2d
[2020-11-30 13:02:56.802305]  | ...
[2020-11-30 13:02:56.803032] DEBUG: test-run received command: eval replica_uuid_ro2 "box.info.replication[1]"
[2020-11-30 13:02:56.804264] DEBUG: test-run's response for [eval replica_uuid_ro2 "box.info.replication[1]"]
[2020-11-30 13:02:56.804264]  | - null
[2020-11-30 13:02:56.804264]  | ...
[2020-11-30 13:02:56.863545] DEBUG: test-run received command: eval replica_uuid_ro2 "box.info.replication[1]"
[2020-11-30 13:02:56.865426] DEBUG: test-run's response for [eval replica_uuid_ro2 "box.info.replication[1]"]
[2020-11-30 13:02:56.865426]  | - null
[2020-11-30 13:02:56.865426]  | ...
[2020-11-30 13:02:56.896547] DEBUG: test-run received command: eval replica_uuid_ro2 "box.info.replication[1]"
[2020-11-30 13:02:56.898011] DEBUG: test-run's response for [eval replica_uuid_ro2 "box.info.replication[1]"]
[2020-11-30 13:02:56.898011]  | - null
[2020-11-30 13:02:56.898011]  | ...
[2020-11-30 13:02:56.958887] DEBUG: test-run received command: eval replica_uuid_ro2 "box.info.replication[1]"
[2020-11-30 13:02:56.960591] DEBUG: test-run's response for [eval replica_uuid_ro2 "box.info.replication[1]"]
[2020-11-30 13:02:56.960591]  | - null
[2020-11-30 13:02:56.960591]  | ...
[2020-11-30 13:02:57.050987] DEBUG: test-run received command: eval replica_uuid_ro2 "box.info.replication[1]"
[2020-11-30 13:02:57.052878] DEBUG: test-run's response for [eval replica_uuid_ro2 "box.info.replication[1]"]
[2020-11-30 13:02:57.052878]  | - null
[2020-11-30 13:02:57.052878]  | ...
[2020-11-30 13:02:57.107417] DEBUG: test-run received command: eval replica_uuid_ro2 "box.info.replication[1]"
[2020-11-30 13:02:57.109231] DEBUG: test-run's response for [eval replica_uuid_ro2 "box.info.replication[1]"]
[2020-11-30 13:02:57.109231]  | - null
[2020-11-30 13:02:57.109231]  | ...
[2020-11-30 13:02:57.188574] DEBUG: test-run received command: eval replica_uuid_ro2 "box.info.replication[1]"
[2020-11-30 13:02:57.190406] DEBUG: test-run's response for [eval replica_uuid_ro2 "box.info.replication[1]"]
[2020-11-30 13:02:57.190406]  | - null
[2020-11-30 13:02:57.190406]  | ...
[2020-11-30 13:02:57.261315] DEBUG: test-run received command: eval replica_uuid_ro2 "box.info.replication[1]"
[2020-11-30 13:02:57.265057] DEBUG: test-run's response for [eval replica_uuid_ro2 "box.info.replication[1]"]
[2020-11-30 13:02:57.265057]  | - id: 1
[2020-11-30 13:02:57.265057]  |   lsn: 10
[2020-11-30 13:02:57.265057]  |   upstream:
[2020-11-30 13:02:57.265057]  |     idle: 0.012409999966621
[2020-11-30 13:02:57.265057]  |     lag: 0.00017714500427246
[2020-11-30 13:02:57.265057]  |     peer: cluster@unix/:/private/tmp/tnt/096_replication/replica_uuid_ro1.sock
[2020-11-30 13:02:57.265057]  |     status: follow
[2020-11-30 13:02:57.265057]  |   uuid: 9cdee878-98e1-4a6f-af4d-fd19d999aa2d
[2020-11-30 13:02:57.265057]  | ...
```

[1] - https://gitlab.com/tarantool/tarantool/-/jobs/878962286
[2] - https://gitlab.com/tarantool/tarantool/-/jobs/879929201/artifacts/download

Closes tarantool/tarantool#5572
