### PR TITLE
Fix lua_eval() routine on broken connections

### DIFF
--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -385,11 +385,17 @@ class TestState(object):
                 "Wrong command for filters: {0}".format(repr(ctype)))
 
     def lua_eval(self, name, expr, silent=True):
-        self.servers[name].admin.reconnect()
-        result = self.servers[name].admin(
-            '%s%s' % (expr, self.delimiter), silent=silent
-        )
-        result = yaml.safe_load(result)
+        try:
+            self.servers[name].admin.reconnect()
+            result = self.servers[name].admin(
+                '%s%s' % (expr, self.delimiter), silent=silent
+            )
+        except KeyError:
+            return []
+        try:
+            result = yaml.safe_load(result)
+        except AttributeError:
+            result = []
         if not result:
             result = []
         return result


### PR DESCRIPTION
Running the testing job:

  https://gitlab.com/tarantool/tarantool/-/jobs/827021220#L5278

found the issue with lua_eval() routine when connection was already
closed, it broke test-run process and the test process:

1. Broken test-run:
```
  [158] replication/election_qsync_stress.test.lua      vinyl
  [158] TarantoolInpector.handle() received the following error:
  [158] Traceback (most recent call last):
  [158]   File "test-run/lib/inspector.py", line 94, in handle
  [158]     result = self.parser.parse_preprocessor(line)
  [158]   File "test-run/lib/preprocessor.py", line 73, in parse_preprocessor
  [158]     return self.lua_eval(name, expr[1:-1])
  [158]   File "test-run/lib/preprocessor.py", line 398, in lua_eval
  [158]     self.servers[name].admin.reconnect()
  [158] KeyError: 'election_replica0'
  [158] [ fail ]
```
2. Failed test:
```
  [158] Test failed! Result content mismatch:
  [158] --- replication/election_qsync_stress.result	Tue Nov  3 10:29:31 2020
  [158] +++ replication/election_qsync_stress.reject	Tue Nov 3 11:07:58 2020
  [158] @@ -107,18 +107,3 @@
  [158]      old_leader_nr = new_leader_nr
  [158]      old_leader = new_leader
  [158]  end;
  [158] - | ---
  [158] - | ...
```
To avoid of the issue exception on missed connection should be checked
and passed to give lua_eval() continue work.