### PR TITLE
Stop replica with SIGKILL if SIGTERM failed

### DIFF
--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -776,7 +776,7 @@ class TarantoolServer(Server):
                         self.vardir)
 
     def prepare_args(self, args=[]):
-        return [self.ctl_path, 'start', os.path.basename(self.script)] + args
+        return [self.ctl_path, 'restart', os.path.basename(self.script)] + args
 
     def pretest_clean(self):
         # Don't delete snap and logs for 'default' tarantool server


### PR DESCRIPTION
Fixed 2 issues:

1. Stop replica with SIGKILL if SIGTERM failed
    
    Found that if the previous test leaves process of the created cluster
    replica then the next same test fails on its recreation [1]:
    ```
      [047] replication/election_qsync_stress.test.lua      vinyl
      [047]
      [047] [Instance "election_replica2" returns with non-zero exit code: 1]
      [047]
      [047] Last 15 lines of Tarantool Log file [Instance
      ...
      [047] 2020-11-05 13:19:25.941 [29831] main/114/applier/unix/:/private/tmp/tnt/047_replication/election_replica3.sock box.cc:183 E> ER_READONLY: Can't modify data because this instance is in read-only mode.
      [047] 2020-11-05 13:19:25.941 [29831] main/103/election_replica2 box.cc:183 E> ER_READONLY: Can't modify data because this instance is in read-only mode.
      [047] 2020-11-05 13:19:25.941 [29831] main/103/election_replica2 F> can't initialize storage: Can't modify data because this instance is in read-only mode.
      [047] 2020-11-05 13:19:25.941 [29831] main/103/election_replica2 F> can't initialize storage: Can't modify data because this instance is in read-only mode.
      [047] [ fail ]
      [047] Test "replication/election_qsync_stress.test.lua", conf: "vinyl"
      [047]         from "fragile" list failed with results file checksum: "133676d72249c570f7124440150a8790", rerunning with server restart ...
      [047] replication/election_qsync_stress.test.lua      vinyl           [ fail ]
      [047] Test "replication/election_qsync_stress.test.lua", conf: "vinyl"
      [047]         from "fragile" list failed with results file checksum: "133676d72249c570f7124440150a8790", rerunning with server restart ...
      [047] replication/election_qsync_stress.test.lua      vinyl           [ fail ]
      ...
    ```
    To fix the issue replica should be killed with signal SIGKILL if
    SIGTERM signal didn't kill it's process.
    
    [1] - https://gitlab.com/tarantool/tarantool/-/jobs/831786472#L5060

2. Use restart instead of start on instance creation
    
    Found that if the previous test leaves process of the created cluster
    replica then the next same test fails on its recreation:
    ```
      [101] replication/ddl.test.lua                        memtx
      [101]
      [101] [Instance "ddl3" returns with non-zero exit code: 1]
      [101]
      [101] Last 15 lines of Tarantool Log file [Instance "ddl3"][/tmp/tnt/101_replication/ddl3.log]:
      ...
      [101] 2020-11-03 10:31:10.589 [6557] main/115/applier/cluster@unix/:/private/tmp/tnt/101_replication/autobootstrap4.sock
           box.cc:183 E> ER_READONLY: Can't modify data because this instance is in read-only mode.
      [101] 2020-11-03 10:31:10.589 [6557] main/103/ddl3 box.cc:183 E> ER_READONLY: Can't modify data because this instance is in read-onlymode.
      [101] 2020-11-03 10:31:10.589 [6557] main/103/ddl3 F> can't initialize storage: Can't modify data because this instance is in read-only mode.
      [101] 2020-11-03 10:31:10.589 [6557] main/103/ddl3 F> can't initialize storage: Can't modify data because this instance is in read-only mode.
      [101] [ fail ]
      [101] Test "replication/ddl.test.lua", conf: "memtx"
      [101]         from "fragile" list failed with results file checksum: "a006d40205b9a67ddbbb8206b4e1764c", rerunning with server restart ...
      [101] replication/ddl.test.lua                        memtx           [ fail ]
      [101] Test "replication/ddl.test.lua", conf: "memtx"
      [101]         from "fragile" list failed with results file checksum: "a3962e843889def7f61d6f1f71461bf1", rerunning with server restart ...
      [101] replication/ddl.test.lua                        memtx           [ fail ]
      [101] Test "replication/ddl.test.lua", conf: "memtx"
      [101]         from "fragile" list failed with results file checksum: "a3962e843889def7f61d6f1f71461bf1", rerunning with server restart ...
      ...
      [101] [Instance "ddl1" returns with non-zero exit code: 1]
      [101]
      [101] Last 15 lines of Tarantool Log file [Instance "ddl1"][/tmp/tnt/101_replication/ddl1.log]:
      [101] The daemon is already running: PID 6553
      [101] Starting instance ddl1...
      [101] The daemon is already running: PID 6553
      [101] Starting instance ddl1...
      ...
    ```
    Found that test-run uses 'tarantoolctl start' call to start the
    instance, but if the previous test failed then on rerun it should
    be stopped before it. To fix it the call changed to 'tarantoolctl
    restart'.
