### PR TITLE
Use SIGKILL in drop_cluster() routine

### DIFF
--- a/test_run.lua
+++ b/test_run.lua
@@ -128,7 +128,7 @@ local function create_cluster(self, servers, test_suite, opts)
     end
 end
 
-local drop_cluster_cmd1 = 'stop server %s'
+local drop_cluster_cmd1 = 'stop server %s with signal=KILL'
 local drop_cluster_cmd2 = 'cleanup server %s'
 local drop_cluster_cmd3 = 'delete server %s'
 


### PR DESCRIPTION
By default drop_cluster() routine uses SIGTERM signal to stop the
replications. Found that in some situations SIGTERM couldn't kill
all replicas and some processes left. To avoid of such situations
better to use SIGKILL signal to be sure that all the replications
processes will be stopped.