### PR TITLE
Set instances restart to SIGKILL by default

### DIFF
--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -776,7 +776,8 @@ class TarantoolServer(Server):
                         self.vardir)
 
     def prepare_args(self, args=[]):
-        return [self.ctl_path, 'start', os.path.basename(self.script)] + args
+        return [self.ctl_path, 'restart', os.path.basename(self.script)] + args \
+                + ['--signal=9']
 
     def pretest_clean(self):
         # Don't delete snap and logs for 'default' tarantool server
@@ -1003,7 +1004,7 @@ class TarantoolServer(Server):
             color_log('    Found old server, pid {0}, killing ...'.format(pid),
                       schema='info')
         try:
-            os.kill(pid, signal.SIGTERM)
+            os.kill(pid, signal.SIGKILL)
         except OSError:
             pass
         self.wait_until_stopped(pid)


### PR DESCRIPTION
Found that some of the instances could not be killed with SIGTERM signal
and it really needed SIGKILL signal to be sure that the instance would
be terminated. Otherwise some tests may fail, like:
```
  No output during 120 seconds. Will abort after 120 seconds without
output. List of workers not reporting the status:
  - 001_engine [engine/json.test.lua, memtx] at
var/001_engine/json.result:598
  Test hung! Result content mismatch:
  --- engine/json.result	Fri Nov  6 08:35:45 2020
  +++ var/001_engine/json.result	Mon Nov  9 03:48:40 2020
  @@ -596,248 +596,3 @@
   - ok
   ...
   test_run:cmd("restart server default")
  -engine = test_run:get_cfg('engine')
  ----
  -…
```
Test run uses 'tarantoolctl' tool for commands in format "restart server
default", and 'tarantoolctl' had only single way to kill it using
SIGTERM signal. To implement ability to use it with SIGKILL was added
additional non-mandatory option to stop and restart 'tarantoolctl'
commands, like:

  tarantoolctl stop <instance> [--signal=SIGKILL]
  tarantoolctl restart <instance> [--signal=SIGKILL]

This options didn't change the backward compatibility of 'tarantoolctl'
tool, but gave test-run ability to stop and restart instances with
SIGKILL signal:

  tarantoolctl restart <instance> --signal=9

It helped to fix the issue with hanging instances in the needed tests.