### PR TITLE
Add signal argument to server restart routine

### DIFF
--- a/.tarantoolctl
+++ b/.tarantoolctl
@@ -1,0 +1,15 @@
+-- Options for test-run tarantoolctl
+
+local workdir = os.getenv('TEST_WORKDIR')
+default_cfg = {
+    pid_file   = workdir,
+    wal_dir    = workdir,
+    memtx_dir  = workdir,
+    vinyl_dir  = workdir,
+    log        = workdir,
+    background = false,
+}
+
+instance_dir = workdir
+
+-- vim: set ft=lua :

--- a/.tarantoolctl
+++ b/.tarantoolctl
@@ -1,6 +1,9 @@
 -- Options for test-run tarantoolctl
 
+-- Note: tonumber(nil) is nil.
 local workdir = os.getenv('TEST_WORKDIR')
+local replication_sync_timeout = tonumber(os.getenv('REPLICATION_SYNC_TIMEOUT'))
+
 default_cfg = {
     pid_file   = workdir,
     wal_dir    = workdir,
@@ -8,6 +11,7 @@ default_cfg = {
     vinyl_dir  = workdir,
     log        = workdir,
     background = false,
+    replication_sync_timeout = replication_sync_timeout,
 }
 
 instance_dir = workdir

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -56,6 +56,8 @@ def module_init():
     TarantoolServer.find_exe(args.builddir)
     UnittestServer.find_exe(args.builddir)
 
+    Options().check_schema_upgrade_option(TarantoolServer.debug)
+
 
 # Init
 ######

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -35,6 +35,11 @@ def module_init():
     os.chdir(path)
     setenv()
 
+    # Keep the PWD environment variable in sync with a current
+    # working directory. It does not strictly necessary, just to
+    # avoid any confusion.
+    os.environ['PWD'] = os.getcwd()
+
     warn_unix_sockets_at_start(args.vardir)
 
     # always run with clean (non-existent) 'var' directory

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -57,6 +57,7 @@ def module_init():
     soext = sys.platform == 'darwin' and 'dylib' or 'so'
     os.environ["LUA_PATH"] = SOURCEDIR+"/?.lua;"+SOURCEDIR+"/?/init.lua;;"
     os.environ["LUA_CPATH"] = BUILDDIR+"/?."+soext+";;"
+    os.environ["REPLICATION_SYNC_TIMEOUT"] = str(args.replication_sync_timeout)
 
     TarantoolServer.find_exe(args.builddir)
     UnittestServer.find_exe(args.builddir)

--- a/lib/colorer.py
+++ b/lib/colorer.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 from lib.singleton import Singleton
 
@@ -147,6 +148,7 @@ class Colorer(object):
     begin = "\033["
     end = "m"
     disable = begin+'0'+end
+    color_re = re.compile('\033' + r'\[\d(?:;\d\d)?m')
 
     def __init__(self):
         # These two fields can be filled later. It's for passing output from
@@ -248,9 +250,16 @@ class Colorer(object):
     def isatty(self):
         return self.is_term
 
+    def decolor(self, data):
+        return self.color_re.sub('', data)
+
 
 # Globals
 #########
 
 
 color_stdout = Colorer()
+
+
+def decolor(data):
+    return color_stdout.decolor(data)

--- a/lib/colorer.py
+++ b/lib/colorer.py
@@ -20,6 +20,33 @@ def color_log(*args, **kwargs):
     color_stdout(*args, **kwargs)
 
 
+def qa_notice(*args, **kwargs):
+    """ Print a notice for an QA engineer at the terminal.
+
+        Example::
+
+            * [QA Notice]
+            *
+            * Attempt to stop already stopped server 'foo'
+            *
+    """
+    # Import from the function to avoid recursive import.
+    from lib.utils import prefix_each_line
+
+    # Use 'info' color by default (yellow).
+    if 'schema' not in kwargs:
+        kwargs = dict(kwargs, schema='info')
+
+    # Join all positional arguments (like color_stdout() do) and
+    # decorate with a header and asterisks.
+    data = ''.join([str(msg) for msg in args])
+    data = prefix_each_line('* ', data)
+    data = '\n* [QA Notice]\n*\n{}*\n'.format(data)
+
+    # Write out.
+    color_stdout(data, **kwargs)
+
+
 class CSchema(object):
     objects = {}
 

--- a/lib/colorer.py
+++ b/lib/colorer.py
@@ -62,6 +62,7 @@ class SchemaAscetic(CSchema):
         'info':      {'fgcolor': 'yellow'},
         'test_var':  {'fgcolor': 'yellow'},
         'test-run command':  {'fgcolor': 'green'},
+        'tarantool command': {'fgcolor': 'blue'},
     }
 
 
@@ -89,6 +90,7 @@ class SchemaPretty(CSchema):
         'log':       {'fgcolor': 'grey'},
         'test_var':  {'fgcolor': 'yellow'},
         'test-run command':  {'fgcolor': 'green'},
+        'tarantool command': {'fgcolor': 'blue'},
     }
 
 

--- a/lib/colorer.py
+++ b/lib/colorer.py
@@ -61,6 +61,7 @@ class SchemaAscetic(CSchema):
         'error':     {'fgcolor': 'red'},
         'info':      {'fgcolor': 'yellow'},
         'test_var':  {'fgcolor': 'yellow'},
+        'test-run command':  {'fgcolor': 'green'},
     }
 
 
@@ -87,6 +88,7 @@ class SchemaPretty(CSchema):
         'tr_text':   {'fgcolor': 'green'},
         'log':       {'fgcolor': 'grey'},
         'test_var':  {'fgcolor': 'yellow'},
+        'test-run command':  {'fgcolor': 'green'},
     }
 
 

--- a/lib/colorer.py
+++ b/lib/colorer.py
@@ -59,6 +59,7 @@ class SchemaAscetic(CSchema):
         'test_skip': {'fgcolor': 'grey'},
         'test_disa': {'fgcolor': 'grey'},
         'error':     {'fgcolor': 'red'},
+        'info':      {'fgcolor': 'yellow'},
         'test_var':  {'fgcolor': 'yellow'},
     }
 

--- a/lib/inspector.py
+++ b/lib/inspector.py
@@ -7,7 +7,9 @@ from gevent.lock import Semaphore
 from gevent.server import StreamServer
 
 from lib.utils import find_port
+from lib.utils import prefix_each_line
 from lib.colorer import color_stdout
+from lib.colorer import color_log
 
 from lib.tarantool_server import TarantoolStartError
 from lib.preprocessor import LuaPreprocessorException
@@ -91,6 +93,9 @@ class TarantoolInspector(StreamServer):
         self.sem.acquire()
 
         for line in self.readline(socket):
+            color_log('DEBUG: test-run received command: {}\n'.format(line),
+                      schema='test-run command')
+
             try:
                 result = self.parser.parse_preprocessor(line)
             except (KeyboardInterrupt, TarantoolStartError):
@@ -111,6 +116,9 @@ class TarantoolInspector(StreamServer):
             result = yaml.dump(result)
             if not result.endswith('...\n'):
                 result = result + '...\n'
+            color_log("DEBUG: test-run's response for [{}]\n{}\n".format(
+                line, prefix_each_line(' | ', result)),
+                schema='test-run command')
             socket.sendall(result)
 
         self.sem.release()

--- a/lib/inspector.py
+++ b/lib/inspector.py
@@ -10,6 +10,7 @@ from lib.utils import find_port
 from lib.utils import prefix_each_line
 from lib.colorer import color_stdout
 from lib.colorer import color_log
+from lib.colorer import qa_notice
 
 from lib.tarantool_server import TarantoolStartError
 from lib.preprocessor import LuaPreprocessorException
@@ -102,8 +103,7 @@ class TarantoolInspector(StreamServer):
                 # propagate to the main greenlet
                 raise
             except LuaPreprocessorException as e:
-                color_stdout('\n* [QA Notice]\n*\n* {0}\n*\n'.format(str(e)),
-                             schema='info')
+                qa_notice(str(e))
                 result = {'error': str(e)}
             except Exception as e:
                 self.parser.kill_current_test()

--- a/lib/inspector.py
+++ b/lib/inspector.py
@@ -10,6 +10,7 @@ from lib.utils import find_port
 from lib.colorer import color_stdout
 
 from lib.tarantool_server import TarantoolStartError
+from lib.preprocessor import LuaPreprocessorException
 
 
 # Module initialization
@@ -95,6 +96,10 @@ class TarantoolInspector(StreamServer):
             except (KeyboardInterrupt, TarantoolStartError):
                 # propagate to the main greenlet
                 raise
+            except LuaPreprocessorException as e:
+                color_stdout('\n* [QA Notice]\n*\n* {0}\n*\n'.format(str(e)),
+                             schema='info')
+                result = {'error': str(e)}
             except Exception as e:
                 self.parser.kill_current_test()
                 color_stdout('\nTarantoolInpector.handle() received the ' +

--- a/lib/options.py
+++ b/lib/options.py
@@ -76,6 +76,14 @@ class Options:
                 Default: false.""")
 
         parser.add_argument(
+                '--debug',
+                dest='debug',
+                action='store_true',
+                default=False,
+                help="""Print test-run logs to the terminal.
+                Default: false.""")
+
+        parser.add_argument(
                 "--force",
                 dest="is_force",
                 action="store_true",

--- a/lib/options.py
+++ b/lib/options.py
@@ -242,12 +242,12 @@ class Options:
         check_error = False
         conflict_options = ('valgrind', 'gdb', 'lldb', 'strace')
         for op1, op2 in product(conflict_options, repeat=2):
-            if op1 != op2 and getattr(self, op1, '') and \
-                    getattr(self, op2, ''):
-                format_str = "Error: option --{} is not compatible \
-                                with option --{}"
+            if op1 != op2 and getattr(self.args, op1, '') and \
+                    getattr(self.args, op2, ''):
+                format_str = "\nError: option --{} is not compatible with option --{}\n"
                 color_stdout(format_str.format(op1, op2), schema='error')
                 check_error = True
+                break
 
         snapshot_path = self.args.snapshot_path
         if self.args.disable_schema_upgrade and not snapshot_path:

--- a/lib/options.py
+++ b/lib/options.py
@@ -202,6 +202,20 @@ class Options:
                 Note: The option works now only with parallel testing.""")
 
         parser.add_argument(
+                "--replication-sync-timeout",
+                dest="replication_sync_timeout",
+                default=100,
+                type=int,
+                help="""The number of seconds that a replica will wait when
+                trying to sync with a master in a cluster, or a quorum of
+                masters, after connecting or during configuration update.
+                This could fail indefinitely if replication_sync_lag is smaller
+                than network latency, or if the replica cannot keep pace with
+                master updates. If replication_sync_timeout expires, the replica
+                enters orphan status.
+                Default: 100 [seconds].""")
+
+        parser.add_argument(
                 "--luacov",
                 dest="luacov",
                 action="store_true",

--- a/lib/options.py
+++ b/lib/options.py
@@ -217,6 +217,20 @@ class Options:
                 help="""Update or create file with reference output (.result).
                 Default: false.""")
 
+        parser.add_argument(
+                "--snapshot",
+                dest='snapshot_path',
+                default=None,
+                type=os.path.abspath,
+                help="""Path to snapshot that will be loaded before testing.""")
+
+        parser.add_argument(
+                "--disable-schema-upgrade",
+                dest='disable_schema_upgrade',
+                action="store_true",
+                default=False,
+                help="""Disable schema upgrade on testing with snapshots.""")
+
         # XXX: We can use parser.parse_intermixed_args() on
         # Python 3.7 to understand commands like
         # ./test-run.py foo --exclude bar baz
@@ -235,5 +249,20 @@ class Options:
                 color_stdout(format_str.format(op1, op2), schema='error')
                 check_error = True
 
+        snapshot_path = self.args.snapshot_path
+        if self.args.disable_schema_upgrade and not snapshot_path:
+            color_stdout("\nOption --disable-schema-upgrade requires --snapshot\n",
+                         schema='error')
+            check_error = True
+
+        if snapshot_path and not os.path.exists(snapshot_path):
+            color_stdout("\nPath {} does not exist\n".format(snapshot_path), schema='error')
+            check_error = True
+
         if check_error:
             exit(-1)
+
+    def check_schema_upgrade_option(self, is_debug):
+        if self.args.disable_schema_upgrade and not is_debug:
+            color_stdout("Can't disable schema upgrade on release build\n", schema='error')
+            exit(1)

--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -229,6 +229,9 @@ class TestState(object):
         if sname not in self.servers:
             raise LuaPreprocessorException(
                 'Can\'t stop nonexistent server {0}'.format(repr(sname)))
+        if not self.servers[sname].status:
+            raise LuaPreprocessorException(
+                'Attempt to stop already stopped server {0}'.format(repr(sname)))
         self.connections[sname].disconnect()
         self.connections.pop(sname)
         if 'signal' in opts:
@@ -399,6 +402,10 @@ class TestState(object):
                 "Wrong command for filters: {0}".format(repr(ctype)))
 
     def lua_eval(self, name, expr, silent=True):
+        if name not in self.servers:
+            raise LuaPreprocessorException('Attempt to evaluate a command on ' +
+                                           'the nonexistent server {0}'.format(
+                                            repr(name)))
         self.servers[name].admin.reconnect()
         result = self.servers[name].admin(
             '%s%s' % (expr, self.delimiter), silent=silent

--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -183,9 +183,6 @@ class TestState(object):
                 "Wrong option: {0}".format(repr(key)))
 
     def server_start(self, ctype, sname, opts):
-        color_log('\nDEBUG: TestState[%s].server_start(%s, %s, %s)\n' % (
-            hex(id(self)), str(ctype), str(sname), str(opts)),
-            schema='test_var')
         if sname not in self.servers:
             raise LuaPreprocessorException(
                 'Can\'t start nonexistent server {0}'.format(repr(sname)))
@@ -223,9 +220,6 @@ class TestState(object):
         return not crash_occured
 
     def server_stop(self, ctype, sname, opts):
-        color_log('\nDEBUG: TestState[%s].server_stop(%s, %s, %s)\n' % (
-            hex(id(self)), str(ctype), str(sname), str(opts)),
-            schema='test_var')
         if sname not in self.servers:
             raise LuaPreprocessorException(
                 'Can\'t stop nonexistent server {0}'.format(repr(sname)))
@@ -247,9 +241,6 @@ class TestState(object):
             self.servers[sname].stop(silent=True)
 
     def server_create(self, ctype, sname, opts):
-        color_log('\nDEBUG: TestState[%s].server_create(%s, %s, %s)\n' % (
-            hex(id(self)), str(ctype), str(sname), str(opts)),
-            schema='test_var')
         if sname in self.servers:
             raise LuaPreprocessorException(
                 'Server {0} already exists'.format(repr(sname)))

--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -17,12 +17,26 @@ class Namespace(object):
 
 
 class LuaPreprocessorException(Exception):
+    """ Raised when evaluation of a test-run command failed.
+
+        This exception is displayed as QA notice on the terminal.
+
+        A Lua error is raised in a test code. The raised object is
+        a string with given error message.
+
+        All other errors that are raised during a command
+        evaluation are considered as show stoppers and lead to
+        stop execution of a test. KeyboardInterrupt and
+        TarantoolStartError stops testing at all, see
+        inspector.py.
+    """
+
     def __init__(self, val):
         super(LuaPreprocessorException, self).__init__()
         self.value = val
 
     def __str__(self):
-        return "lua preprocessor error: {0}".format(repr(self.value))
+        return self.value
 
 
 class TestState(object):

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -848,6 +848,12 @@ class TarantoolServer(Server):
             os.putenv("MASTER", self.rpl_master.iproto.uri)
         self.logfile_pos = self.logfile
 
+        # This is strange, but tarantooctl leans on the PWD
+        # environment variable, not a real current working
+        # directory, when it performs search for the
+        # .tarantoolctl configuration file.
+        os.environ['PWD'] = self.vardir
+
         # redirect stdout from tarantoolctl and tarantool
         os.putenv("TEST_WORKDIR", self.vardir)
         self.process = subprocess.Popen(args,
@@ -855,6 +861,9 @@ class TarantoolServer(Server):
                                         stdout=self.log_des,
                                         stderr=self.log_des)
         del(self.log_des)
+
+        # Restore the actual PWD value.
+        os.environ['PWD'] = os.getcwd()
 
         # gh-19 crash detection
         self.crash_detector = TestRunGreenlet(self.crash_detect)

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -470,10 +470,6 @@ class TarantoolServer(Server):
 
     # ----------------------------PROPERTIES--------------------------------- #
     @property
-    def debug(self):
-        return self.test_debug()
-
-    @property
     def name(self):
         if not hasattr(self, '_name') or not self._name:
             return self.default_tarantool["name"]
@@ -700,6 +696,8 @@ class TarantoolServer(Server):
                         ctl_dir + '/?.lua;' + \
                         ctl_dir + '/?/init.lua;' + \
                         os.environ.get("LUA_PATH", ";;")
+                cls.debug = bool(re.findall(r'-Debug', str(cls.version()),
+                                 re.I))
                 return exe
         raise RuntimeError("Can't find server executable in " + path)
 
@@ -1090,11 +1088,6 @@ class TarantoolServer(Server):
 
     def test_option(self, option_list_str):
         print self.test_option_get(option_list_str)
-
-    def test_debug(self):
-        if re.findall(r"-Debug", self.test_option_get("-V", True), re.I):
-            return True
-        return False
 
     @staticmethod
     def find_tests(test_suite, suite_path):

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -169,6 +169,8 @@ class LuaTest(Test):
 
     def send_command_raw(self, command, ts):
         """ Send a command to tarantool and read a response. """
+        color_log('DEBUG: sending command: {}\n'.format(command.rstrip()),
+                  schema='tarantool command')
         # Evaluate the request on the first connection, save the
         # response.
         result = ts.curcon[0](command, silent=True)
@@ -178,6 +180,9 @@ class LuaTest(Test):
         # gh-24 fix
         if result is None:
             result = '[Lost current connection]\n'
+        color_log("DEBUG: tarantool's response for [{}]\n{}\n".format(
+            command.rstrip(), prefix_each_line(' | ', result)),
+            schema='tarantool command')
         return result
 
     def set_language(self, ts, language):

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -776,7 +776,15 @@ class TarantoolServer(Server):
                     if (e.errno == errno.ENOENT):
                         continue
                     raise
-        shutil.copy('.tarantoolctl', self.vardir)
+        # Previously tarantoolctl configuration file located in tarantool
+        # repository at test/ directory. Currently it is located in root
+        # path of test-run/ submodule repository. For backward compatibility
+        # this file should be checked at the old place and only after at
+        # the current.
+        tntctl_file = '.tarantoolctl'
+        if not os.path.exists(tntctl_file):
+            tntctl_file = os.path.join(self.TEST_RUN_DIR, '.tarantoolctl')
+        shutil.copy(tntctl_file, self.vardir)
         shutil.copy(os.path.join(self.TEST_RUN_DIR, 'test_run.lua'),
                     self.vardir)
         # Need to use get here because of nondefault servers doesn't have ini.

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -1064,8 +1064,8 @@ class TarantoolServer(Server):
             if os.path.exists(self._admin.port):
                 os.unlink(self._admin.port)
 
-    def restart(self):
-        self.stop()
+    def restart(self, signal=signal.SIGTERM):
+        self.stop(signal)
         self.start()
 
     def kill_old_server(self, silent=True):

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -237,7 +237,7 @@ def print_unidiff(filepath_a, filepath_b):
             ctime = time.ctime(os.stat(filepath).st_mtime)
         except Exception:
             if not os.path.exists(filepath):
-                color_stdout('[File does not exists: {}]'.format(filepath),
+                color_stdout('[File does not exist: {}]\n'.format(filepath),
                              schema='error')
             lines = []
             ctime = time.ctime()

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -7,6 +7,8 @@ import random
 import fcntl
 import difflib
 import time
+import json
+import subprocess
 from gevent import socket
 from lib.colorer import color_stdout
 try:
@@ -264,3 +266,40 @@ def just_and_trim(src, width):
     if len(src) > width:
         return src[:width - 1] + '>'
     return src.ljust(width)
+
+
+def xlog_rows(xlog_path):
+    """ Parse xlog / snapshot file.
+
+        Assume tarantool and tarantoolctl is in PATH.
+    """
+    cmd = ['tarantoolctl', 'cat', xlog_path, '--format=json', '--show-system']
+    with open(os.devnull, 'w') as devnull:
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=devnull)
+    for line in process.stdout.readlines():
+        yield json.loads(line)
+
+
+def extract_schema_from_snapshot(snapshot_path):
+    """
+    Extract schema version from snapshot.
+
+    Assume tarantool and tarantoolctl is in PATH.
+
+    Example of record:
+
+     {
+       "HEADER": {"lsn":2, "type": "INSERT", "timestamp": 1584694286.0031},
+       "BODY": {"space_id": 272, "tuple": ["version", 2, 3, 1]}
+     }
+
+    :returns: [u'version', 2, 3, 1]
+    """
+    BOX_SCHEMA_ID = 272
+    for row in xlog_rows(snapshot_path):
+        if row['HEADER']['type'] == 'INSERT' and \
+           row['BODY']['space_id'] == BOX_SCHEMA_ID:
+            res = row['BODY']['tuple']
+            if res[0] == 'version':
+                return res
+    return None

--- a/lib/worker.py
+++ b/lib/worker.py
@@ -5,6 +5,7 @@ import os
 import signal
 import traceback
 import yaml
+from datetime import datetime
 
 import lib
 from lib.colorer import color_log
@@ -166,6 +167,7 @@ class WorkerOutput(BaseWorkerMessage):
         super(WorkerOutput, self).__init__(worker_id, worker_name)
         self.output = output
         self.log_only = log_only
+        self.timestamp = datetime.isoformat(datetime.now(), ' ')
 
 
 class WorkerDone(BaseWorkerMessage):

--- a/listeners.py
+++ b/listeners.py
@@ -258,11 +258,20 @@ class HangWatcher(BaseWatcher):
         self.worker_current_task = dict()
 
     def process_result(self, obj):
-        self.warned_seconds_ago = 0.0
-        self.inactivity = 0.0
-
+        # Track tasks in progress.
         if isinstance(obj, WorkerCurrentTask):
             self.worker_current_task[obj.worker_id] = obj
+
+        # Skip irrelevant events.
+        if not isinstance(obj, WorkerOutput):
+            return
+
+        # Skip color_log() events if --debug is not passed.
+        if obj.log_only and not lib.Options().args.debug:
+            return
+
+        self.warned_seconds_ago = 0.0
+        self.inactivity = 0.0
 
     def process_timeout(self, delta_seconds):
         self.warned_seconds_ago += delta_seconds

--- a/listeners.py
+++ b/listeners.py
@@ -147,7 +147,13 @@ class LogOutputWatcher(BaseWatcher):
             filepath = self.get_logfile(obj.worker_name)
             self.fds[obj.worker_id] = open(filepath, 'w')
         fd = self.fds[obj.worker_id]
-        fd.write(obj.output)
+
+        # Prefix each line with a timestamp.
+        output = obj.output
+        prefix = '[{}] '.format(obj.timestamp)
+        output = prefix_each_line(prefix, output)
+
+        fd.write(output)
         fd.flush()
 
     def __del__(self):

--- a/listeners.py
+++ b/listeners.py
@@ -148,8 +148,20 @@ class LogOutputWatcher(BaseWatcher):
             self.fds[obj.worker_id] = open(filepath, 'w')
         fd = self.fds[obj.worker_id]
 
-        # Prefix each line with a timestamp.
+        # Mark chunks without newlines at the end.
+        #
+        # In OutputWatcher() such chunks are bufferized and
+        # written to the terminal when a newline arrives (to
+        # don't mix partial lines from different workers).
+        #
+        # Here we want to dump output without any buffering,
+        # because it may help with debugging a problem. So
+        # we just mark such chunks and write them out.
         output = obj.output
+        if not decolor(output).endswith('\n'):
+            output = output + ' <no newline>\n'
+
+        # Prefix each line with a timestamp.
         prefix = '[{}] '.format(obj.timestamp)
         output = prefix_each_line(prefix, output)
 

--- a/listeners.py
+++ b/listeners.py
@@ -200,7 +200,12 @@ class OutputWatcher(BaseWatcher):
                 del self.buffer[obj.worker_id]
             return
 
-        if not isinstance(obj, WorkerOutput) or obj.log_only:
+        # Skip irrelevant events.
+        if not isinstance(obj, WorkerOutput):
+            return
+
+        # Skip color_log() events if --debug is not passed.
+        if obj.log_only and not lib.Options().args.debug:
             return
 
         bufferized = self.buffer.get(obj.worker_id, '')

--- a/listeners.py
+++ b/listeners.py
@@ -1,11 +1,11 @@
 import os
-import re
 import sys
 import yaml
 import shutil
 
 import lib
 from lib.colorer import color_stdout
+from lib.colorer import decolor
 from lib.worker import WorkerCurrentTask
 from lib.worker import WorkerDone
 from lib.worker import WorkerOutput
@@ -159,8 +159,6 @@ class LogOutputWatcher(BaseWatcher):
 
 
 class OutputWatcher(BaseWatcher):
-    color_re = re.compile('\033' + r'\[\d(?:;\d\d)?m')
-
     def __init__(self):
         self.buffer = dict()
 
@@ -175,10 +173,6 @@ class OutputWatcher(BaseWatcher):
         output = OutputWatcher.add_prefix(output, worker_id)
         sys.stdout.write(output)
 
-    @staticmethod
-    def _decolor(obj):
-        return OutputWatcher.color_re.sub('', obj)
-
     def process_result(self, obj):
         if isinstance(obj, WorkerDone):
             bufferized = self.buffer.get(obj.worker_id, '')
@@ -192,7 +186,7 @@ class OutputWatcher(BaseWatcher):
             return
 
         bufferized = self.buffer.get(obj.worker_id, '')
-        if OutputWatcher._decolor(obj.output).endswith('\n'):
+        if decolor(obj.output).endswith('\n'):
             OutputWatcher._write(bufferized + obj.output, obj.worker_id)
             self.buffer[obj.worker_id] = ''
         else:

--- a/listeners.py
+++ b/listeners.py
@@ -208,6 +208,11 @@ class OutputWatcher(BaseWatcher):
         if obj.log_only and not lib.Options().args.debug:
             return
 
+        # Prepend color_log() messages with a timestamp.
+        if obj.log_only:
+            prefix = '[{}] '.format(obj.timestamp)
+            obj.output = prefix_each_line(prefix, obj.output)
+
         bufferized = self.buffer.get(obj.worker_id, '')
         if decolor(obj.output).endswith('\n'):
             OutputWatcher._write(bufferized + obj.output, obj.worker_id)

--- a/test_run.lua
+++ b/test_run.lua
@@ -134,7 +134,8 @@ local drop_cluster_cmd3 = 'delete server %s'
 
 local function drop_cluster(self, servers)
     for _, name in ipairs(servers) do
-        self:cmd(drop_cluster_cmd1:format(name))
+        -- Don't fail on already stopped servers.
+        pcall(self.cmd, self, drop_cluster_cmd1:format(name))
         self:cmd(drop_cluster_cmd2:format(name))
         self:cmd(drop_cluster_cmd3:format(name))
     end

--- a/test_run.lua
+++ b/test_run.lua
@@ -20,7 +20,7 @@ local function cmd(self, msg)
     sock:close()
     result = yaml.decode(result)
     if type(result) == 'table' and result.error ~= nil then
-        error(result.error)
+        error(result.error, 0)
     end
     return result
 end


### PR DESCRIPTION
Found that stop and restart routines should have the ability to set
signal using restart routine to fix the issues, like:
```
Test hung! Result content mismatch:
--- replication-py/init_storage.result	Wed Aug 26 06:06:15 2020
+++ /tmp/tnt/101_replication-py/init_storage.result	Wed Nov 11
10:17:50 2020
@@ -130,5 +130,3 @@
 -------------------------------------------------------------
 waiting reconnect on JOIN...
 ok
-waiting reconnect on SUBSCRIBE...
-ok
```