### PR TITLE
Improve observability of the testing system

### DIFF
--- a/lib/colorer.py
+++ b/lib/colorer.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 from lib.singleton import Singleton
 
@@ -147,6 +148,7 @@ class Colorer(object):
     begin = "\033["
     end = "m"
     disable = begin+'0'+end
+    color_re = re.compile('\033' + r'\[\d(?:;\d\d)?m')
 
     def __init__(self):
         # These two fields can be filled later. It's for passing output from
@@ -248,9 +250,16 @@ class Colorer(object):
     def isatty(self):
         return self.is_term
 
+    def decolor(self, data):
+        return self.color_re.sub('', data)
+
 
 # Globals
 #########
 
 
 color_stdout = Colorer()
+
+
+def decolor(data):
+    return color_stdout.decolor(data)

--- a/lib/colorer.py
+++ b/lib/colorer.py
@@ -62,6 +62,7 @@ class SchemaAscetic(CSchema):
         'info':      {'fgcolor': 'yellow'},
         'test_var':  {'fgcolor': 'yellow'},
         'test-run command':  {'fgcolor': 'green'},
+        'tarantool command': {'fgcolor': 'blue'},
     }
 
 
@@ -89,6 +90,7 @@ class SchemaPretty(CSchema):
         'log':       {'fgcolor': 'grey'},
         'test_var':  {'fgcolor': 'yellow'},
         'test-run command':  {'fgcolor': 'green'},
+        'tarantool command': {'fgcolor': 'blue'},
     }
 
 

--- a/lib/colorer.py
+++ b/lib/colorer.py
@@ -61,6 +61,7 @@ class SchemaAscetic(CSchema):
         'error':     {'fgcolor': 'red'},
         'info':      {'fgcolor': 'yellow'},
         'test_var':  {'fgcolor': 'yellow'},
+        'test-run command':  {'fgcolor': 'green'},
     }
 
 
@@ -87,6 +88,7 @@ class SchemaPretty(CSchema):
         'tr_text':   {'fgcolor': 'green'},
         'log':       {'fgcolor': 'grey'},
         'test_var':  {'fgcolor': 'yellow'},
+        'test-run command':  {'fgcolor': 'green'},
     }
 
 

--- a/lib/colorer.py
+++ b/lib/colorer.py
@@ -59,6 +59,7 @@ class SchemaAscetic(CSchema):
         'test_skip': {'fgcolor': 'grey'},
         'test_disa': {'fgcolor': 'grey'},
         'error':     {'fgcolor': 'red'},
+        'info':      {'fgcolor': 'yellow'},
         'test_var':  {'fgcolor': 'yellow'},
     }
 

--- a/lib/inspector.py
+++ b/lib/inspector.py
@@ -7,7 +7,9 @@ from gevent.lock import Semaphore
 from gevent.server import StreamServer
 
 from lib.utils import find_port
+from lib.utils import prefix_each_line
 from lib.colorer import color_stdout
+from lib.colorer import color_log
 
 from lib.tarantool_server import TarantoolStartError
 from lib.preprocessor import LuaPreprocessorException
@@ -91,6 +93,9 @@ class TarantoolInspector(StreamServer):
         self.sem.acquire()
 
         for line in self.readline(socket):
+            color_log('DEBUG: test-run received command: {}\n'.format(line),
+                      schema='test-run command')
+
             try:
                 result = self.parser.parse_preprocessor(line)
             except (KeyboardInterrupt, TarantoolStartError):
@@ -111,6 +116,9 @@ class TarantoolInspector(StreamServer):
             result = yaml.dump(result)
             if not result.endswith('...\n'):
                 result = result + '...\n'
+            color_log("DEBUG: test-run's response for [{}]\n{}\n".format(
+                line, prefix_each_line(' | ', result)),
+                schema='test-run command')
             socket.sendall(result)
 
         self.sem.release()

--- a/lib/inspector.py
+++ b/lib/inspector.py
@@ -10,6 +10,7 @@ from lib.utils import find_port
 from lib.colorer import color_stdout
 
 from lib.tarantool_server import TarantoolStartError
+from lib.preprocessor import LuaPreprocessorException
 
 
 # Module initialization
@@ -95,6 +96,10 @@ class TarantoolInspector(StreamServer):
             except (KeyboardInterrupt, TarantoolStartError):
                 # propagate to the main greenlet
                 raise
+            except LuaPreprocessorException as e:
+                color_stdout('\n* [QA Notice]\n*\n* {0}\n*\n'.format(str(e)),
+                             schema='info')
+                result = {'error': str(e)}
             except Exception as e:
                 self.parser.kill_current_test()
                 color_stdout('\nTarantoolInpector.handle() received the ' +

--- a/lib/options.py
+++ b/lib/options.py
@@ -76,6 +76,14 @@ class Options:
                 Default: false.""")
 
         parser.add_argument(
+                '--debug',
+                dest='debug',
+                action='store_true',
+                default=False,
+                help="""Print test-run logs to the terminal.
+                Default: false.""")
+
+        parser.add_argument(
                 "--force",
                 dest="is_force",
                 action="store_true",

--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -229,6 +229,9 @@ class TestState(object):
         if sname not in self.servers:
             raise LuaPreprocessorException(
                 'Can\'t stop nonexistent server {0}'.format(repr(sname)))
+        if not self.servers[sname].status:
+            raise LuaPreprocessorException(
+                'Attempt to stop already stopped server {0}'.format(repr(sname)))
         self.connections[sname].disconnect()
         self.connections.pop(sname)
         if 'signal' in opts:
@@ -399,6 +402,10 @@ class TestState(object):
                 "Wrong command for filters: {0}".format(repr(ctype)))
 
     def lua_eval(self, name, expr, silent=True):
+        if name not in self.servers:
+            raise LuaPreprocessorException('Attempt to evaluate a command on ' +
+                                           'the nonexistent server {0}'.format(
+                                            repr(name)))
         self.servers[name].admin.reconnect()
         result = self.servers[name].admin(
             '%s%s' % (expr, self.delimiter), silent=silent

--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -183,9 +183,6 @@ class TestState(object):
                 "Wrong option: {0}".format(repr(key)))
 
     def server_start(self, ctype, sname, opts):
-        color_log('\nDEBUG: TestState[%s].server_start(%s, %s, %s)\n' % (
-            hex(id(self)), str(ctype), str(sname), str(opts)),
-            schema='test_var')
         if sname not in self.servers:
             raise LuaPreprocessorException(
                 'Can\'t start nonexistent server {0}'.format(repr(sname)))
@@ -223,9 +220,6 @@ class TestState(object):
         return not crash_occured
 
     def server_stop(self, ctype, sname, opts):
-        color_log('\nDEBUG: TestState[%s].server_stop(%s, %s, %s)\n' % (
-            hex(id(self)), str(ctype), str(sname), str(opts)),
-            schema='test_var')
         if sname not in self.servers:
             raise LuaPreprocessorException(
                 'Can\'t stop nonexistent server {0}'.format(repr(sname)))
@@ -247,9 +241,6 @@ class TestState(object):
             self.servers[sname].stop(silent=True)
 
     def server_create(self, ctype, sname, opts):
-        color_log('\nDEBUG: TestState[%s].server_create(%s, %s, %s)\n' % (
-            hex(id(self)), str(ctype), str(sname), str(opts)),
-            schema='test_var')
         if sname in self.servers:
             raise LuaPreprocessorException(
                 'Server {0} already exists'.format(repr(sname)))

--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -17,12 +17,26 @@ class Namespace(object):
 
 
 class LuaPreprocessorException(Exception):
+    """ Raised when evaluation of a test-run command failed.
+
+        This exception is displayed as QA notice on the terminal.
+
+        A Lua error is raised in a test code. The raised object is
+        a string with given error message.
+
+        All other errors that are raised during a command
+        evaluation are considered as show stoppers and lead to
+        stop execution of a test. KeyboardInterrupt and
+        TarantoolStartError stops testing at all, see
+        inspector.py.
+    """
+
     def __init__(self, val):
         super(LuaPreprocessorException, self).__init__()
         self.value = val
 
     def __str__(self):
-        return "lua preprocessor error: {0}".format(repr(self.value))
+        return self.value
 
 
 class TestState(object):

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -169,6 +169,8 @@ class LuaTest(Test):
 
     def send_command_raw(self, command, ts):
         """ Send a command to tarantool and read a response. """
+        color_log('DEBUG: sending command: {}\n'.format(command.rstrip()),
+                  schema='tarantool command')
         # Evaluate the request on the first connection, save the
         # response.
         result = ts.curcon[0](command, silent=True)
@@ -178,6 +180,9 @@ class LuaTest(Test):
         # gh-24 fix
         if result is None:
             result = '[Lost current connection]\n'
+        color_log("DEBUG: tarantool's response for [{}]\n{}\n".format(
+            command.rstrip(), prefix_each_line(' | ', result)),
+            schema='tarantool command')
         return result
 
     def set_language(self, ts, language):

--- a/lib/worker.py
+++ b/lib/worker.py
@@ -5,6 +5,7 @@ import os
 import signal
 import traceback
 import yaml
+from datetime import datetime
 
 import lib
 from lib.colorer import color_log
@@ -166,6 +167,7 @@ class WorkerOutput(BaseWorkerMessage):
         super(WorkerOutput, self).__init__(worker_id, worker_name)
         self.output = output
         self.log_only = log_only
+        self.timestamp = datetime.isoformat(datetime.now(), ' ')
 
 
 class WorkerDone(BaseWorkerMessage):

--- a/listeners.py
+++ b/listeners.py
@@ -258,11 +258,20 @@ class HangWatcher(BaseWatcher):
         self.worker_current_task = dict()
 
     def process_result(self, obj):
-        self.warned_seconds_ago = 0.0
-        self.inactivity = 0.0
-
+        # Track tasks in progress.
         if isinstance(obj, WorkerCurrentTask):
             self.worker_current_task[obj.worker_id] = obj
+
+        # Skip irrelevant events.
+        if not isinstance(obj, WorkerOutput):
+            return
+
+        # Skip color_log() events if --debug is not passed.
+        if obj.log_only and not lib.Options().args.debug:
+            return
+
+        self.warned_seconds_ago = 0.0
+        self.inactivity = 0.0
 
     def process_timeout(self, delta_seconds):
         self.warned_seconds_ago += delta_seconds

--- a/listeners.py
+++ b/listeners.py
@@ -147,7 +147,13 @@ class LogOutputWatcher(BaseWatcher):
             filepath = self.get_logfile(obj.worker_name)
             self.fds[obj.worker_id] = open(filepath, 'w')
         fd = self.fds[obj.worker_id]
-        fd.write(obj.output)
+
+        # Prefix each line with a timestamp.
+        output = obj.output
+        prefix = '[{}] '.format(obj.timestamp)
+        output = prefix_each_line(prefix, output)
+
+        fd.write(output)
         fd.flush()
 
     def __del__(self):

--- a/listeners.py
+++ b/listeners.py
@@ -148,8 +148,20 @@ class LogOutputWatcher(BaseWatcher):
             self.fds[obj.worker_id] = open(filepath, 'w')
         fd = self.fds[obj.worker_id]
 
-        # Prefix each line with a timestamp.
+        # Mark chunks without newlines at the end.
+        #
+        # In OutputWatcher() such chunks are bufferized and
+        # written to the terminal when a newline arrives (to
+        # don't mix partial lines from different workers).
+        #
+        # Here we want to dump output without any buffering,
+        # because it may help with debugging a problem. So
+        # we just mark such chunks and write them out.
         output = obj.output
+        if not decolor(output).endswith('\n'):
+            output = output + ' <no newline>\n'
+
+        # Prefix each line with a timestamp.
         prefix = '[{}] '.format(obj.timestamp)
         output = prefix_each_line(prefix, output)
 

--- a/listeners.py
+++ b/listeners.py
@@ -200,7 +200,12 @@ class OutputWatcher(BaseWatcher):
                 del self.buffer[obj.worker_id]
             return
 
-        if not isinstance(obj, WorkerOutput) or obj.log_only:
+        # Skip irrelevant events.
+        if not isinstance(obj, WorkerOutput):
+            return
+
+        # Skip color_log() events if --debug is not passed.
+        if obj.log_only and not lib.Options().args.debug:
             return
 
         bufferized = self.buffer.get(obj.worker_id, '')

--- a/listeners.py
+++ b/listeners.py
@@ -1,11 +1,11 @@
 import os
-import re
 import sys
 import yaml
 import shutil
 
 import lib
 from lib.colorer import color_stdout
+from lib.colorer import decolor
 from lib.worker import WorkerCurrentTask
 from lib.worker import WorkerDone
 from lib.worker import WorkerOutput
@@ -159,8 +159,6 @@ class LogOutputWatcher(BaseWatcher):
 
 
 class OutputWatcher(BaseWatcher):
-    color_re = re.compile('\033' + r'\[\d(?:;\d\d)?m')
-
     def __init__(self):
         self.buffer = dict()
 
@@ -175,10 +173,6 @@ class OutputWatcher(BaseWatcher):
         output = OutputWatcher.add_prefix(output, worker_id)
         sys.stdout.write(output)
 
-    @staticmethod
-    def _decolor(obj):
-        return OutputWatcher.color_re.sub('', obj)
-
     def process_result(self, obj):
         if isinstance(obj, WorkerDone):
             bufferized = self.buffer.get(obj.worker_id, '')
@@ -192,7 +186,7 @@ class OutputWatcher(BaseWatcher):
             return
 
         bufferized = self.buffer.get(obj.worker_id, '')
-        if OutputWatcher._decolor(obj.output).endswith('\n'):
+        if decolor(obj.output).endswith('\n'):
             OutputWatcher._write(bufferized + obj.output, obj.worker_id)
             self.buffer[obj.worker_id] = ''
         else:

--- a/listeners.py
+++ b/listeners.py
@@ -208,6 +208,11 @@ class OutputWatcher(BaseWatcher):
         if obj.log_only and not lib.Options().args.debug:
             return
 
+        # Prepend color_log() messages with a timestamp.
+        if obj.log_only:
+            prefix = '[{}] '.format(obj.timestamp)
+            obj.output = prefix_each_line(prefix, obj.output)
+
         bufferized = self.buffer.get(obj.worker_id, '')
         if decolor(obj.output).endswith('\n'):
             OutputWatcher._write(bufferized + obj.output, obj.worker_id)

--- a/test_run.lua
+++ b/test_run.lua
@@ -134,7 +134,8 @@ local drop_cluster_cmd3 = 'delete server %s'
 
 local function drop_cluster(self, servers)
     for _, name in ipairs(servers) do
-        self:cmd(drop_cluster_cmd1:format(name))
+        -- Don't fail on already stopped servers.
+        pcall(self.cmd, self, drop_cluster_cmd1:format(name))
         self:cmd(drop_cluster_cmd2:format(name))
         self:cmd(drop_cluster_cmd3:format(name))
     end

--- a/test_run.lua
+++ b/test_run.lua
@@ -20,7 +20,7 @@ local function cmd(self, msg)
     sock:close()
     result = yaml.decode(result)
     if type(result) == 'table' and result.error ~= nil then
-        error(result.error)
+        error(result.error, 0)
     end
     return result
 end


### PR DESCRIPTION
Sometimes it is hard to understand what exactly the testing system doing. In this patchset I made attempt to improve its observability: give meaningful error messages, log more events and so on.

I picked up [one of the tests][1], which fails from time to time, and use it as a test for the testing system: run it, look at output and logs, change test-run to give me useful details, repeat.

[1]: https://github.com/tarantool/tarantool/issues/5395