### PR TITLE
Move tarantoolctl to test-run tool submodule and add replication_sync_timeout to it

### DIFF
--- a/.tarantoolctl
+++ b/.tarantoolctl
@@ -1,0 +1,15 @@
+-- Options for test-run tarantoolctl
+
+local workdir = os.getenv('TEST_WORKDIR')
+default_cfg = {
+    pid_file   = workdir,
+    wal_dir    = workdir,
+    memtx_dir  = workdir,
+    vinyl_dir  = workdir,
+    log        = workdir,
+    background = false,
+}
+
+instance_dir = workdir
+
+-- vim: set ft=lua :

--- a/.tarantoolctl
+++ b/.tarantoolctl
@@ -1,6 +1,9 @@
 -- Options for test-run tarantoolctl
 
+-- Note: tonumber(nil) is nil.
 local workdir = os.getenv('TEST_WORKDIR')
+local replication_sync_timeout = tonumber(os.getenv('REPLICATION_SYNC_TIMEOUT'))
+
 default_cfg = {
     pid_file   = workdir,
     wal_dir    = workdir,
@@ -8,6 +11,7 @@ default_cfg = {
     vinyl_dir  = workdir,
     log        = workdir,
     background = false,
+    replication_sync_timeout = replication_sync_timeout,
 }
 
 instance_dir = workdir

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -35,6 +35,11 @@ def module_init():
     os.chdir(path)
     setenv()
 
+    # Keep the PWD environment variable in sync with a current
+    # working directory. It does not strictly necessary, just to
+    # avoid any confusion.
+    os.environ['PWD'] = os.getcwd()
+
     warn_unix_sockets_at_start(args.vardir)
 
     # always run with clean (non-existent) 'var' directory

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -57,6 +57,7 @@ def module_init():
     soext = sys.platform == 'darwin' and 'dylib' or 'so'
     os.environ["LUA_PATH"] = SOURCEDIR+"/?.lua;"+SOURCEDIR+"/?/init.lua;;"
     os.environ["LUA_CPATH"] = BUILDDIR+"/?."+soext+";;"
+    os.environ["REPLICATION_SYNC_TIMEOUT"] = str(args.replication_sync_timeout)
 
     TarantoolServer.find_exe(args.builddir)
     UnittestServer.find_exe(args.builddir)

--- a/lib/options.py
+++ b/lib/options.py
@@ -202,6 +202,20 @@ class Options:
                 Note: The option works now only with parallel testing.""")
 
         parser.add_argument(
+                "--replication-sync-timeout",
+                dest="replication_sync_timeout",
+                default=100,
+                type=int,
+                help="""The number of seconds that a replica will wait when
+                trying to sync with a master in a cluster, or a quorum of
+                masters, after connecting or during configuration update.
+                This could fail indefinitely if replication_sync_lag is smaller
+                than network latency, or if the replica cannot keep pace with
+                master updates. If replication_sync_timeout expires, the replica
+                enters orphan status.
+                Default: 100 [seconds].""")
+
+        parser.add_argument(
                 "--luacov",
                 dest="luacov",
                 action="store_true",

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -848,6 +848,12 @@ class TarantoolServer(Server):
             os.putenv("MASTER", self.rpl_master.iproto.uri)
         self.logfile_pos = self.logfile
 
+        # This is strange, but tarantooctl leans on the PWD
+        # environment variable, not a real current working
+        # directory, when it performs search for the
+        # .tarantoolctl configuration file.
+        os.environ['PWD'] = self.vardir
+
         # redirect stdout from tarantoolctl and tarantool
         os.putenv("TEST_WORKDIR", self.vardir)
         self.process = subprocess.Popen(args,
@@ -855,6 +861,9 @@ class TarantoolServer(Server):
                                         stdout=self.log_des,
                                         stderr=self.log_des)
         del(self.log_des)
+
+        # Restore the actual PWD value.
+        os.environ['PWD'] = os.getcwd()
 
         # gh-19 crash detection
         self.crash_detector = TestRunGreenlet(self.crash_detect)

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -776,7 +776,15 @@ class TarantoolServer(Server):
                     if (e.errno == errno.ENOENT):
                         continue
                     raise
-        shutil.copy('.tarantoolctl', self.vardir)
+        # Previously tarantoolctl configuration file located in tarantool
+        # repository at test/ directory. Currently it is located in root
+        # path of test-run/ submodule repository. For backward compatibility
+        # this file should be checked at the old place and only after at
+        # the current.
+        tntctl_file = '.tarantoolctl'
+        if not os.path.exists(tntctl_file):
+            tntctl_file = os.path.join(self.TEST_RUN_DIR, '.tarantoolctl')
+        shutil.copy(tntctl_file, self.vardir)
         shutil.copy(os.path.join(self.TEST_RUN_DIR, 'test_run.lua'),
                     self.vardir)
         # Need to use get here because of nondefault servers doesn't have ini.


### PR DESCRIPTION
1. Move tarantoolctl to test-run tool submodule
    
    Moved tarantoolctl to test-run tool submodule repository as:
    
      <tarantool repository>/test-run/.tarantoolctl
    
    Also set backward compability to use old path location:
    
      <tarantool repository>/test/.tarantoolctl
    
    as its primary place.

    To set PWD environment for tarantoolctl for popen() call tried to use
    os.environ. It was needed for the later commits where tarantoolctl
    would be moved from to test-run repository and its configuration file
    would be read right from the working directory of the test. In this
    case all os.putenv() calls changed to environment set with os.environ,
    to be able to modify environment directly, check [1] ("Note: Calling
    putenv() directly does not change os.environ"). But in this case all
    the tests had to be changed to use os.environ instead of os.putenv(),
    it will block the use of os.putenv() in the future tests. Decided to
    avoid of this way and temporary change 'PWD' around the Popen() call.
    
    Needed for tarantool/tarantool#5504
    Part of #78
    
    [1] - https://docs.python.org/2/library/os.html#process-parameters

2. Setup replication_sync_timeout at .tarantoolctl
    
    Found that tests may fail due to hang in seek_wait() loop on starting
    and stopping instances. It happened, because instances were not synced
    within default output timeout which is by default 120 seconds, while
    replication sync happens only each 300 seconds by default. To fix it
    replication_sync_timeout should be decreased to some value lower than
    'no-output-timeout', so decided to set it to 100 seconds.

    The issue looked like in tests:
    ```
      --- replication/gh-5140-qsync-casc-rollback.result    Mon Oct 19
      17:29:46 2020
      +++ /rw_bins/test/var/070_replication/gh-5140-qsync-casc-rollback.result
      Mon Oct 19 17:31:35 2020
      @@ -169,56 +169,3 @@
       -- all the records are replayed one be one without yields for WAL writes, and
       -- nothing should change.
       test_run:cmd('restart server default')
      - |
      -test_run:cmd('restart server replica')
      - | ---
      - | - true
      - | ...
      -
    ```
    Part of tarantool/tarantool#5504
