### PR TITLE
Handle lack of a last result file at a worker hang

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -235,7 +235,7 @@ def print_unidiff(filepath_a, filepath_b):
             ctime = time.ctime(os.stat(filepath).st_mtime)
         except Exception:
             if not os.path.exists(filepath):
-                color_stdout('[File does not exists: {}]'.format(filepath),
+                color_stdout('[File does not exist: {}]\n'.format(filepath),
                              schema='error')
             lines = []
             ctime = time.ctime()


### PR DESCRIPTION
When there is no output from workers during a long time (10 seconds by
default or 60 seconds when --long argument is passed), test-run prints a
warning and shows amount of lines in the temporary result file. It is
useful to understand on which statement a test hungs.

I reproduced the problem, when mangled tarantool to ignore SIGTERM and 
SIGINT signals and run a simple 'tarantool = core' test. The test
successfully passes, but the worker stucks in waiting for stopping the 
tarantool server.

This particular case should be resolved in PR #186, but just because the 
timeout for stopping the server is less than the warning delay. This
assumption looks fragile, especially if we'll want to make some of those
timeouts / delays configurable. Let's handle the situation when the file
does not exist.

Found while looking into
https://github.com/tarantool/tarantool/issues/5573

Fixes #245

----

Also fixed a grammar in a result file diff output, when a file does not exist.