### PR TITLE
Stop instances properly

### DIFF
--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -2,6 +2,7 @@ import errno
 import glob
 import os
 import shutil
+import signal
 import sys
 
 from gevent.subprocess import Popen, PIPE
@@ -73,7 +74,10 @@ class AppTest(Test):
         finally:
             # Stop any servers created by the test, except the
             # default one.
-            ts.stop_nondefault()
+            #
+            # See a comment in LuaTest.execute() for motivation of
+            # SIGKILL usage.
+            ts.stop_nondefault(signal=signal.SIGKILL)
         if retval['returncode'] != 0:
             raise TestExecutionError
 

--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -70,6 +70,10 @@ class AppTest(Test):
         except TarantoolStartError:
             # A non-default server failed to start.
             raise TestExecutionError
+        finally:
+            # Stop any servers created by the test, except the
+            # default one.
+            ts.stop_nondefault()
         if retval['returncode'] != 0:
             raise TestExecutionError
 

--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -78,7 +78,7 @@ class AppTest(Test):
             # See a comment in LuaTest.execute() for motivation of
             # SIGKILL usage.
             ts.stop_nondefault(signal=signal.SIGKILL)
-        if retval['returncode'] != 0:
+        if retval.get('returncode', None) != 0:
             raise TestExecutionError
 
 

--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -427,8 +427,9 @@ class TestState(object):
         self.parse_preprocessor(string)
 
     def stop_nondefault(self):
-        color_log('\nDEBUG: TestState[%s].stop_nondefault()\n'
-                  % hex(id(self)), schema='test_var')
+        names = [k for k in self.servers.keys() if k != 'default']
+        color_log('DEBUG: Stop non-default servers: {}\n'.format(names),
+                  schema='info')
         if sys.stdout.__class__.__name__ == 'FilteredStream':
             sys.stdout.clear_all_filters()
         for k, v in self.servers.iteritems():
@@ -441,8 +442,9 @@ class TestState(object):
                 self.connections.pop(k)
 
     def cleanup_nondefault(self):
-        color_log('\nDEBUG: TestState[%s].cleanup_nondefault()\n' %
-                  hex(id(self)), schema='test_var')
+        names = [k for k in self.servers.keys() if k != 'default']
+        color_log('DEBUG: Cleanup non-default servers: {}\n'.format(names),
+                  schema='info')
         for k, v in self.servers.iteritems():
             # don't cleanup the default server
             if k == 'default':

--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -1,5 +1,6 @@
 import os
 import shlex
+import signal
 import sys
 from collections import deque
 
@@ -10,6 +11,7 @@ import six
 from lib.admin_connection import AdminAsyncConnection
 from lib.colorer import color_log
 from lib.utils import signum
+from lib.utils import signame
 
 
 class Namespace(object):
@@ -426,17 +428,18 @@ class TestState(object):
         string = string[3:].strip()
         self.parse_preprocessor(string)
 
-    def stop_nondefault(self):
+    def stop_nondefault(self, signal=signal.SIGTERM):
         names = [k for k in self.servers.keys() if k != 'default']
-        color_log('DEBUG: Stop non-default servers: {}\n'.format(names),
-                  schema='info')
+        color_log('DEBUG: Stop non-default servers using '
+                  'signal {} ({}): {}\n'.format(signal, signame(signal),
+                                                names), schema='info')
         if sys.stdout.__class__.__name__ == 'FilteredStream':
             sys.stdout.clear_all_filters()
         for k, v in self.servers.iteritems():
             # don't stop the default server
             if k == 'default':
                 continue
-            v.stop(silent=True)
+            v.stop(silent=True, signal=signal)
             if k in self.connections:
                 self.connections[k].disconnect()
                 self.connections.pop(k)

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -1048,7 +1048,10 @@ class TarantoolServer(Server):
                           'Sending SIGKILL...'.format(
                               self.name, timeout, signal, signame(signal),
                               format_process(self.process.pid)))
-                self.process.kill()
+                try:
+                    self.process.kill()
+                except OSError:
+                    pass
 
             timer = Timer(timeout, kill)
             timer.start()


### PR DESCRIPTION
Attempt to get rid of 'The daemon is already running' error and hang instances after testing.

- Wait for a process to terminate after a signal to get rid of the 'The daemon is already running' error.
- Stop supplementary (non-default) instances after an app test.
- Use SIGKILL, when SIGTERM is not sufficient for non-default instance of an app test (follows up #186).
- Kill an app server if it hangs and a non-default instance fails.

I use the test cases from the PR #244 and tweak them to hang or fail instances at different points: before startup or after. Say, hang a default app server and fail a supplementary one after startup.

Follows up PR #244.
Fixes #65.
Fixes #157.

----


While looking into this, found several doubtful situations or code: #252, #253, #254, #255, #256.