### PR TITLE
Add timeouts setup from environment

### DIFF
--- a/dispatcher.py
+++ b/dispatcher.py
@@ -143,10 +143,9 @@ class Dispatcher:
             self.listeners.append(self.fail_watcher)
         if watch_hang:
             warn_timeout = 60.0 if args.long else 10.0
-            no_output_timeout = float(args.no_output_timeout or 120)
             hang_watcher = listeners.HangWatcher(
                 output_watcher.not_done_worker_ids, self.kill_all_workers,
-                warn_timeout, no_output_timeout)
+                warn_timeout, float(args.no_output_timeout))
             self.listeners.append(hang_watcher)
 
     def run_max_workers(self):

--- a/lib/options.py
+++ b/lib/options.py
@@ -193,7 +193,7 @@ class Options:
         parser.add_argument(
                 "--test-timeout",
                 dest="test_timeout",
-                default=110,
+                default=env_int('TEST_TIMEOUT', 110),
                 type=int,
                 help="""Break the test process with kill signal if the test runs
                 longer than this amount of seconds. Default: 110 [seconds].""")
@@ -201,7 +201,7 @@ class Options:
         parser.add_argument(
                 "--no-output-timeout",
                 dest="no_output_timeout",
-                default=0,
+                default=env_int('NO_OUTPUT_TIMEOUT', 120),
                 type=int,
                 help="""Exit if there was no output from workers during this
                 amount of seconds. Set it to -1 to disable hang detection.
@@ -212,7 +212,7 @@ class Options:
         parser.add_argument(
                 "--replication-sync-timeout",
                 dest="replication_sync_timeout",
-                default=100,
+                default=env_int('REPLICATION_SYNC_TIMEOUT', 100),
                 type=int,
                 help="""The number of seconds that a replica will wait when
                 trying to sync with a master in a cluster, or a quorum of

--- a/test-run.py
+++ b/test-run.py
@@ -73,7 +73,8 @@ EXIT_UNKNOWN_ERROR = 50
 def main_loop_parallel():
     color_stdout("Started {0}\n".format(" ".join(sys.argv)), schema='tr_text')
 
-    jobs = lib.Options().args.jobs
+    args = lib.Options().args
+    jobs = args.jobs
     if jobs < 1:
         # faster result I got was with 2 * cpu_count
         jobs = 2 * multiprocessing.cpu_count()
@@ -82,6 +83,16 @@ def main_loop_parallel():
         color_stdout("Running in parallel with %d workers\n\n" % jobs,
                      schema='tr_text')
     randomize = True
+
+    color_stdout("Timeout options:\n", schema='tr_text')
+    color_stdout('-' * 19, "\n",       schema='separator')
+    color_stdout("REPLICATION_SYNC_TIMEOUT:" . ljust(26) + "{}\n" .
+                 format(args.replication_sync_timeout), schema='tr_text')
+    color_stdout("TEST_TIMEOUT:" . ljust(26) + "{}\n" .
+                 format(args.test_timeout), schema='tr_text')
+    color_stdout("NO_OUTPUT_TIMEOUT:" . ljust(26) + "{}\n" .
+                 format(args.no_output_timeout), schema='tr_text')
+    color_stdout("\n", schema='tr_text')
 
     task_groups = lib.worker.get_task_groups()
     if lib.Options().args.reproduce:


### PR DESCRIPTION
Added ability to set using environment the following timeouts based on
appropriate run options:
```
  TEST_TIMEOUT			--test-timeout
  NO_OUTPUT_TIMEOUT		--no-output-timeout
  REPLICATION_SYNC_TIMEOUT	--replication-sync-timeout
```
Closes #258