### PR TITLE
Add check in wait_lsn for nil value

### DIFF
--- a/test_run.lua
+++ b/test_run.lua
@@ -64,9 +64,10 @@ end
 local function wait_lsn(self, waiter, master)
     local sid = self:get_server_id(master)
     local lsn = self:get_lsn(master, sid)
-
-    while self:get_lsn(waiter, sid) < lsn do
+    local remote_lsn = self:get_lsn(waiter, sid)
+    while remote_lsn == nil or remote_lsn < lsn do
         fiber.sleep(0.001)
+        remote_lsn = self:get_lsn(waiter, sid)
     end
 end
 


### PR DESCRIPTION
Found issue in testing:
```    
      [006] --- replication/election_qsync.result   Fri Oct 16 00:12:02 2020
      [006] +++ replication/election_qsync.reject   Sat Oct 17 19:08:11 2020
      [006] @@ -89,6 +89,8 @@
      [006]  -- Wait replication to the other instance.
      [006]  test_run:wait_lsn('default', 'replica')
      [006]   | ---
      [006] + | - error: '...sitories/tarantool/test/var/006_replication/test_run.lua:68: attempt
      [006] + |     to compare nil with number'
      [006]   | ...
```    
Found that wait_lsn() routine from test_run.lua script failed on
comparing returned result from get_lsn() routine with real integer.
It happened because get_lsn() returned 'nil' on the freshly
bootstrapped instance. It happened when replica vclock [1:x, 2:1],
while master vclock [1:x, 2:0], but in box.info.vclock[2] is nil
instead of 0. To avoid of it in wait_lsn() routine added check that
get_lsn() routine returned not 'nil' value. Complete explanation of
the issue and reproducer provided in [1].

This test showed the issue in test-run which could happen with any
test that uses test_run:wait_lsn() routine. This patch fixes this
routine to be able to work correctly with 'nil' value returned by
get_lsn() routine.
    
Closes tarantool/test-run#226
    
Co-authored-by: Alexander Turenko <alexander.turenko@tarantool.org>
    
[1]: https://github.com/tarantool/test-run/pull/269#issuecomment-789373803
