### PR TITLE
OSError on process.terminate on hard loaded hosts

### DIFF
--- a/dispatcher.py
+++ b/dispatcher.py
@@ -112,7 +112,10 @@ class Dispatcher:
     def terminate_all_workers(self):
         for process in self.processes:
             if process.is_alive():
-                process.terminate()
+                try:
+                    process.terminate()
+                except OSError:
+                    pass
 
     def kill_all_workers(self):
         for pid in self.pids:


### PR DESCRIPTION
Found issue:
```
  No output during 10 seconds. Will abort after 120 seconds without output. List of workers not reporting the status:
  - 001_sql-tap [sql-tap/index4.test.lua, vinyl] at var_hdd_test/001_sql-tap/index4.result:0
  [001] sql-tap/index4.test.lua                         vinyl           Test timeout of 110 secs reached  [ fail ]
  [001] Test failed! Output from reject file var_hdd_test/rejects/sql-tap/index4.reject:
  [001]
  [001] Last 15 lines of Tarantool Log file [Instance "app_server"][/source/test/var_hdd_test/001_sql-tap/index4.test.lua:vinyl.tarantool.log]:
  [Main process] Got failed test; gently terminate all workers...
  Traceback (most recent call last):
    File "./test-run.py", line 230, in <module>
      status = main_parallel()
    File "./test-run.py", line 145, in main_parallel
      res = main_loop_parallel()
    File "./test-run.py", line 117, in main_loop_parallel
      dispatcher.wait()
    File "/source/test-run/dispatcher.py", line 278, in wait
      objs = self.invoke_listeners(inputs, ready_inputs)
    File "/source/test-run/dispatcher.py", line 309, in invoke_listeners
      listener.process_result(obj)
    File "/source/test-run/listeners.py", line 241, in process_result
      self.terminate_all_workers()
    File "/source/test-run/dispatcher.py", line 115, in terminate_all_workers
      process.terminate()
    File "/usr/lib/python2.7/multiprocessing/process.py", line 137, in terminate
      self._popen.terminate()
    File "/usr/lib/python2.7/multiprocessing/forking.py", line 171, in terminate
      os.kill(self.pid, signal.SIGTERM)
  OSError: [Errno 3] No such process

  real    2m18.661s
  user    0m3.541s
  sys     0m46.695s
```
It happened because process.terminate() routine was too slow to kill the
needed process that the process already exited at the time of routine
call. Added exception handler on OSError interrupt to avoid of test-run
fails.

Closes #270