### PR TITLE
Implement new option, which allows to set allocator for memtx

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -58,6 +58,7 @@ def module_init():
     os.environ["LUA_PATH"] = SOURCEDIR+"/?.lua;"+SOURCEDIR+"/?/init.lua;;"
     os.environ["LUA_CPATH"] = BUILDDIR+"/?."+soext+";;"
     os.environ["REPLICATION_SYNC_TIMEOUT"] = str(args.replication_sync_timeout)
+    os.environ['MEMTX_ALLOCATOR'] = args.memtx_allocator
 
     TarantoolServer.find_exe(args.builddir)
     UnittestServer.find_exe(args.builddir)

--- a/lib/options.py
+++ b/lib/options.py
@@ -252,6 +252,11 @@ class Options:
                 action="store_true",
                 default=False,
                 help="""Disable schema upgrade on testing with snapshots.""")
+        parser.add_argument(
+                "--memtx-allocator",
+                dest="memtx_allocator",
+                default=os.environ.get("MEMTX_ALLOCATOR", "small"),
+                help="""Memtx allocator type for tests""")
 
         # XXX: We can use parser.parse_intermixed_args() on
         # Python 3.7 to understand commands like


### PR DESCRIPTION
The ability to select an allocator for memtx has been added to
tarantool. To test a new type of allocator, all tests must also
be run with it. Implemented new option, which allows to set allocator
for memtx. If you wan't to choose allocator type for tests, run test-run.py
with --memtx-allocator="small" or --memtx-allocator="system". Allocator type
is passed via MEMTX_ALLOCATOR environment variable to the test.

Part of https://github.com/tarantool/tarantool/issues/5419