### PR TITLE
Renew dependencies

### DIFF
--- a/lib/server_mixins.py
+++ b/lib/server_mixins.py
@@ -1,7 +1,13 @@
 import os
 import glob
 import shlex
-from six.moves import shlex_quote
+
+try:
+    # Python 3.3+.
+    from shlex import quote as shlex_quote
+except ImportError:
+    # Python 2.7.
+    from pipes import quote as shlex_quote
 
 from lib.utils import find_in_path
 from lib.utils import print_tail_n

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 PyYAML==5.1
-argparse==1.1
-msgpack-python==0.4.6
 gevent==21.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyYAML==5.1
-gevent==21.1.2
+PyYAML==5.*
+gevent==21.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ PyYAML==5.1
 argparse==1.1
 msgpack-python==0.4.6
 gevent==21.1.2
-six>=1.8.0


### PR DESCRIPTION
- Drop six, argparse, msgpack-python.
- Relax PyYAML and gevent version requirements (freeze only major version).

Supersedes PR #282.