### PR TITLE
Fix slowdown on Python 3

### DIFF
--- a/lib/colorer.py
+++ b/lib/colorer.py
@@ -1,7 +1,6 @@
 import os
 import re
 import sys
-from lib.singleton import Singleton
 
 
 # Use it to print messages on the screen and to the worker's log.
@@ -128,7 +127,6 @@ class Colorer(object):
     1. ftp://ftp.cs.utk.edu/pub/shuford/terminal/dec_vt220_codes.txt
     2. http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
     """
-    __metaclass__ = Singleton
     fgcolor = {
         "black":     '0;30',
         "red":       '0;31',

--- a/lib/options.py
+++ b/lib/options.py
@@ -2,7 +2,6 @@ import os
 import sys
 import argparse
 from itertools import product
-from lib.singleton import Singleton
 
 from lib.colorer import color_stdout
 
@@ -23,13 +22,27 @@ def env_list(name, default):
     return value_list or default
 
 
-class Options:
+class Options(object):
     """Handle options of test-runner"""
 
-    __metaclass__ = Singleton
+    _instance = None
+    _initialized = False
+
+    def __new__(cls, *args, **kwargs):
+        """Make the class singleton."""
+        if cls._instance:
+            return cls._instance
+        cls._instance = super(Options, cls).__new__(cls, *args, **kwargs)
+        return cls._instance
 
     def __init__(self):
         """Add all program options, with their defaults."""
+
+        # The __init__() method is called always, even when we
+        # return already initialized Options instance from
+        # __new__().
+        if Options._initialized:
+            return
 
         parser = argparse.ArgumentParser(
             description="Tarantool regression test suite front-end.")
@@ -263,6 +276,8 @@ class Options:
         # ./test-run.py foo --exclude bar baz
         self.args = parser.parse_args()
         self.check()
+
+        Options._initialized = True
 
     def check(self):
         """Check the arguments for correctness."""

--- a/lib/singleton.py
+++ b/lib/singleton.py
@@ -1,8 +1,0 @@
-class Singleton(type):
-    _instances = {}
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(
-                *args, **kwargs)
-        return cls._instances[cls]


### PR DESCRIPTION
Don't parse command line arguments each time `Options()` is called.

The metaclass syntax was changed in Python 3 (see [1]) and it is tricky
to add a metaclass in a Python version agnostic way. Still possible, but 
the code would be hard to understand. So I get rid of the Singleton
metaclass and use \_\_new\_\_() to implement this logic.

Aside of the Option class, we had another singleton: Colorer. However it
is instanciated once (this instance is exposed as color_stdout) and it
does not matter, whether it is a singleton or not.

A brief testing on tarantool's test suite (with --long --force) gives me
~8 minutes after the fix instead of ~11 minutes before the fix. However
it worth to note that we have a lot of tests, which are marked as
fragile and so run without parallelization. Otherwise the difference
would be lower, I guess.

[1]: https://www.python.org/dev/peps/pep-3115/

Fixes #279