### PR TITLE
Add RSS memory status collecting routine to get RSS per tests and workers

### DIFF
--- a/lib/options.py
+++ b/lib/options.py
@@ -271,6 +271,14 @@ class Options(object):
                 default=os.environ.get("MEMTX_ALLOCATOR", "small"),
                 help="""Memtx allocator type for tests""")
 
+        parser.add_argument(
+                "--collect-statistics",
+                dest="collect_statistics",
+                action="store_true",
+                default=False,
+                help="""Collect memory/disk host statistics usage.
+                Default: false.""")
+
         # XXX: We can use parser.parse_intermixed_args() on
         # Python 3.7 to understand commands like
         # ./test-run.py foo --exclude bar baz

--- a/lib/pytap13.py
+++ b/lib/pytap13.py
@@ -18,6 +18,8 @@
 
 import re
 
+from lib.colorer import color_log
+
 try:
     # Python 2
     from StringIO import StringIO
@@ -139,6 +141,7 @@ class TAP13(object):
 
             if seek_test:
                 m = RE_TEST_LINE.match(line)
+                color_log('%s\n' % line, schema='test-run command')
                 if m and on_top_level:
                     self.__tests_counter += 1
                     t_attrs = m.groupdict()

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import collections
 import signal
@@ -231,6 +232,19 @@ def format_process(pid):
     except (OSError, IOError):
         pass
     return 'process %d [%s; %s]' % (pid, status, cmdline)
+
+
+def get_mem_stat_rss():
+    rss = 'unknown'
+    pat = re.compile(r"^total_rss .*")
+    try:
+        with open('/sys/fs/cgroup/memory/memory.stat', 'r') as f:
+            for line in f:
+                if pat.match(line) is not None:
+                    rss = line.split(' ')[1]
+    except (OSError, IOError):
+        pass
+    return rss
 
 
 def set_fd_cloexec(socket):

--- a/listeners.py
+++ b/listeners.py
@@ -15,6 +15,7 @@ from lib.utils import prefix_each_line
 from lib.utils import safe_makedirs
 from lib.utils import print_tail_n
 from lib.utils import print_unidiff
+from lib.utils import get_mem_stat_rss
 
 
 class BaseWatcher(object):
@@ -168,6 +169,9 @@ class LogOutputWatcher(BaseWatcher):
         output = prefix_each_line(prefix, output)
 
         fd.write(output)
+        if (Options().args.collect_statistics):
+            rss = '{}RSS: {}' . format(prefix, get_mem_stat_rss())
+            fd.write(rss)
         fd.flush()
 
     def __del__(self):


### PR DESCRIPTION
Patch set consists of 2 commits:

1. Add RSS memory status collecting routine
    
    Added RSS memory status collecting routine which parses file:

    `      /sys/fs/cgroup/memory/memory.stat`

    for RSS value and run this routine after each sent test lua command in
    listeners. All results it collects in main tests worker log file:

    `      var/log/<worker name>.log`

    For this routine use added test-run new option:

    `      --collect-statistics`

    which should be used to use this routine.

    Closes tarantool/tarantool-qa#98

2. Enable logging TAP tests on each testing condition

    Found that TAP test do not print any information on tested conditions
    in tests worker log file. It can be used to check test stages for
    data written into this log file.