### PR TITLE
Fix --reproduce mode for fragile tests

### DIFF
--- a/lib/worker.py
+++ b/lib/worker.py
@@ -106,7 +106,7 @@ def reproduce_task_groups(task_groups):
     for i, task_id in enumerate(reproduce):
         for key, task_group in task_groups.items():
             if task_id in task_group['task_ids']:
-                found_keys.append(key)
+                found_keys.append(key.rstrip('_fragile'))
                 break
         if len(found_keys) != i + 1:
             raise ValueError('[reproduce] Cannot find test "%s"' %


### PR DESCRIPTION
Previously, if reproduce file contained both fragile and stable tests
test run would failed. To avoid this case fragile tests now are using
as a stable.

Fixes: #233