### PR TITLE
Add RSS statistics and timings collecting

### DIFF
--- a/dispatcher.py
+++ b/dispatcher.py
@@ -167,8 +167,9 @@ class Dispatcher:
         self.statistics = StatisticsWatcher(log_output_watcher.get_logfile)
         self.artifacts = ArtifactsWatcher(log_output_watcher.get_logfile)
         output_watcher = OutputWatcher()
-        self.listeners = [self.statistics, log_output_watcher, output_watcher, self.artifacts,
-                          sampler.watcher]
+        self.listeners = [self.statistics, log_output_watcher, output_watcher, self.artifacts]
+        if sampler.is_enabled:
+            self.listeners.append(sampler.watcher)
         if watch_fail:
             self.fail_watcher = FailWatcher(self.terminate_all_workers)
             self.listeners.append(self.fail_watcher)

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -34,6 +34,7 @@ except ImportError:
     from multiprocessing.queues import SimpleQueue
 
 from lib import Options
+from lib.sampler import sampler
 from lib.utils import set_fd_cloexec
 from lib.worker import WorkerTaskResult, WorkerDone
 from lib.colorer import color_stdout
@@ -121,7 +122,7 @@ class Dispatcher:
             self.result_queues.append(task_queue_disp.result_queue)
             self.task_queues.append(task_queue_disp.task_queue)
 
-        self.report_timeout = 1.0
+        self.report_timeout = 0.1
 
         self.statistics = None
         self.artifacts = None
@@ -166,7 +167,8 @@ class Dispatcher:
         self.statistics = StatisticsWatcher(log_output_watcher.get_logfile)
         self.artifacts = ArtifactsWatcher(log_output_watcher.get_logfile)
         output_watcher = OutputWatcher()
-        self.listeners = [self.statistics, log_output_watcher, output_watcher, self.artifacts]
+        self.listeners = [self.statistics, log_output_watcher, output_watcher, self.artifacts,
+                          sampler.watcher]
         if watch_fail:
             self.fail_watcher = FailWatcher(self.terminate_all_workers)
             self.listeners.append(self.fail_watcher)
@@ -416,6 +418,7 @@ class TaskQueueDispatcher:
         os.environ['TEST_RUN_TCP_PORT_END'] = str(tcp_port_range[1])
         color_stdout.queue = self.result_queue
         worker = self.gen_worker(worker_id)
+        sampler.set_queue(self.result_queue, worker_id, worker.name)
         worker.run_all(self.task_queue, self.result_queue)
 
     def add_worker(self, worker_id, tcp_port_range):

--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -13,6 +13,7 @@ from lib.colorer import color_log
 from lib.colorer import qa_notice
 from lib.options import Options
 from lib.preprocessor import TestState
+from lib.sampler import sampler
 from lib.server import Server
 from lib.server import DEFAULT_SNAPSHOT_NAME
 from lib.tarantool_server import Test
@@ -31,9 +32,10 @@ def timeout_handler(server_process, test_timeout):
     server_process.kill()
 
 
-def run_server(execs, cwd, server, logfile, retval):
+def run_server(execs, cwd, server, logfile, retval, test_id):
     os.putenv("LISTEN", server.iproto)
     server.process = Popen(execs, stdout=PIPE, stderr=PIPE, cwd=cwd)
+    sampler.register_process(server.process.pid, test_id, server.name)
     test_timeout = Options().args.test_timeout
     timer = Timer(test_timeout, timeout_handler, (server.process, test_timeout))
     timer.start()
@@ -57,7 +59,7 @@ class AppTest(Test):
         execs = server.prepare_args()
         retval = dict()
         tarantool = TestRunGreenlet(run_server, execs, server.vardir, server,
-                                    server.logfile, retval)
+                                    server.logfile, retval, self.id)
         self.current_test_greenlet = tarantool
 
         # Copy the snapshot right before starting the server.

--- a/lib/sampler.py
+++ b/lib/sampler.py
@@ -1,0 +1,155 @@
+import os
+import sys
+import time
+
+from lib.colorer import color_log
+from lib.colorer import qa_notice
+from lib.utils import format_process
+
+
+if sys.version_info[0] == 2:
+    ProcessLookupError = OSError
+
+
+# Don't inherit BaseWorkerMessage to bypass cyclic import.
+class RegisterProcessMessage(object):
+    """Ask the sampler in the main test-run process to register
+       given process.
+    """
+    def __init__(self, worker_id, worker_name, pid, task_id, server_name):
+        self.worker_id = worker_id
+        self.worker_name = worker_name
+        self.pid = pid
+        self.task_id = task_id
+        self.server_name = server_name
+
+
+# Don't inherit BaseWatcher to bypass cyclic import.
+class SamplerWatcher(object):
+    def __init__(self, sampler):
+        self._sampler = sampler
+        self._last_sample = 0
+        self._sample_interval = 0.1  # seconds
+        self._warn_interval = self._sample_interval * 4
+
+    def process_result(self, obj):
+        if isinstance(obj, RegisterProcessMessage):
+            self._sampler.register_process(
+                obj.pid, obj.task_id, obj.server_name, obj.worker_id,
+                obj.worker_name)
+        self._wakeup()
+
+    def process_timeout(self, delta_seconds):
+        self._wakeup()
+
+    def _wakeup(self):
+        """Invoke Sampler.sample() if enough time elapsed since
+           the previous call.
+        """
+        now = time.time()
+        delta = now - self._last_sample
+        if self._last_sample > 0 and delta > self._warn_interval:
+            template = 'Low sampling resolution. The expected interval\n' + \
+                       'is {:.2f} seconds ({:.2f} seconds without warnings),\n' + \
+                       'but the last sample was collected {:.2f} seconds ago.'
+            qa_notice(template.format(self._sample_interval, self._warn_interval,
+                                      delta))
+        if delta > self._sample_interval:
+            self._sampler._sample()
+            self._last_sample = now
+
+
+class Sampler:
+    def __init__(self):
+        # The instance is created in the test-run main process.
+
+        # Field for an instance in a worker.
+        self._worker_id = None
+        self._worker_name = None
+        self._queue = None
+
+        # Field for an instance in the main process.
+        self._watcher = SamplerWatcher(self)
+
+        self._processes = dict()
+
+    def set_queue(self, queue, worker_id, worker_name):
+        # Called from a worker process (_run_worker()).
+        self._worker_id = worker_id
+        self._worker_name = worker_name
+        self._queue = queue
+        self._watcher = None
+
+    @property
+    def watcher(self):
+        if not self._watcher:
+            raise RuntimeError('sampler: watcher is available only in the ' +
+                               'main test-run process')
+        return self._watcher
+
+    def register_process(self, pid, task_id, server_name, worker_id=None,
+                         worker_name=None):
+        """Register a process to sampling.
+
+           Call it without worker_* arguments from a worker
+           process.
+        """
+        if not self._queue:
+            # In main test-run process.
+            self._processes[pid] = {
+                'task_id': task_id,
+                'server_name': server_name,
+                'worker_id': worker_id,
+                'worker_name': worker_name,
+            }
+            self._log('register', pid)
+            return
+
+        # Pass to the main test-run process.
+        self._queue.put(RegisterProcessMessage(
+            self._worker_id, self._worker_name, pid, task_id, server_name))
+
+    def unregister_process(self, pid):
+        if self._queue:
+            raise NotImplementedError('sampler: a process unregistration ' +
+                                      'from a test-run worker is not ' +
+                                      'implemented yet')
+        if pid not in self._processes:
+            return
+
+        self._log('unregister', pid)
+        del self._processes[pid]
+
+    def _log(self, event, pid):
+        # Those logs are not written due to gh-247.
+        process_def = self._processes[pid]
+        task_id = process_def['task_id']
+        test_name = task_id[0] + ((':' + task_id[1]) if task_id[1] else '')
+        worker_name = process_def['worker_name']
+        server_name = process_def['server_name']
+        color_log('DEBUG: sampler: {} {}\n'.format(
+                  event, format_process(pid)), schema='info')
+        color_log(' | worker: {}\n'.format(worker_name))
+        color_log(' | test: {}\n'.format(test_name))
+        color_log(' | server: {}\n'.format(str(server_name)))
+
+    def _sample(self):
+        for pid in list(self._processes.keys()):
+            # Unregister processes that're gone.
+            # Assume that PIDs are rarely reused.
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                self.unregister_process(pid)
+            else:
+                self._sample_process(pid)
+
+    def _sample_process(self, pid):
+        # Your sampling code here.
+        pass
+
+
+# The 'singleton' sampler instance: created in the main test-run
+# process, but then work differently in the main process and
+# workers.
+sampler = Sampler()

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -32,6 +32,7 @@ from lib.colorer import color_log
 from lib.colorer import qa_notice
 from lib.options import Options
 from lib.preprocessor import TestState
+from lib.sampler import sampler
 from lib.server import Server
 from lib.server import DEFAULT_SNAPSHOT_NAME
 from lib.test import Test
@@ -332,6 +333,10 @@ class LuaTest(Test):
 
     def execute(self, server):
         super(LuaTest, self).execute(server)
+
+        # Track the same process metrics as part of another test.
+        sampler.register_process(server.process.pid, self.id, server.name)
+
         cls_name = server.__class__.__name__.lower()
         if 'gdb' in cls_name or 'lldb' in cls_name or 'strace' in cls_name:
             # don't propagate gdb/lldb/strace mixin to non-default servers,
@@ -399,6 +404,10 @@ class PythonTest(Test):
 
     def execute(self, server):
         super(PythonTest, self).execute(server)
+
+        # Track the same process metrics as part of another test.
+        sampler.register_process(server.process.pid, self.id, server.name)
+
         new_globals = dict(locals(), test_run_current_test=self, **server.__dict__)
         with open(self.name) as f:
             code = compile(f.read(), self.name, 'exec')
@@ -865,6 +874,12 @@ class TarantoolServer(Server):
 
         # Restore the actual PWD value.
         os.environ['PWD'] = os.getcwd()
+
+        # Track non-default server metrics as part of current
+        # test.
+        if self.current_test:
+            sampler.register_process(self.process.pid, self.current_test.id,
+                                     self.name)
 
         # gh-19 crash detection
         self.crash_detector = TestRunGreenlet(self.crash_detect)

--- a/lib/test_suite.py
+++ b/lib/test_suite.py
@@ -289,3 +289,6 @@ class TestSuite:
 
     def show_reproduce_content(self):
         return self.ini['show_reproduce_content']
+
+    def test_is_long(self, task_id):
+        return os.path.basename(task_id[0]) in self.ini['long_run']

--- a/lib/test_suite.py
+++ b/lib/test_suite.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import sys
+import time
 
 from lib import Options
 from lib.app_server import AppServer
@@ -268,18 +269,20 @@ class TestSuite:
             conf = test.conf_name
         color_stdout(just_and_trim(conf, 15) + ' ', schema='test_var')
 
+        start_time = time.time()
         if self.is_test_enabled(test, conf, server):
             short_status, result_checksum = test.run(server)
         else:
             color_stdout("[ disabled ]\n", schema='t_name')
             short_status = 'disabled'
             result_checksum = None
+        duration = time.time() - start_time
 
         # cleanup only if test passed or if --force mode enabled
         if Options().args.is_force or short_status == 'pass':
             inspector.cleanup_nondefault()
 
-        return short_status, result_checksum
+        return short_status, result_checksum, duration
 
     def is_parallel(self):
         return self.ini['is_parallel']

--- a/lib/unittest_server.py
+++ b/lib/unittest_server.py
@@ -4,6 +4,7 @@ import sys
 import glob
 from subprocess import Popen, PIPE, STDOUT
 
+from lib.sampler import sampler
 from lib.server import Server
 from lib.tarantool_server import Test
 from lib.tarantool_server import TarantoolServer
@@ -18,6 +19,7 @@ class UnitTest(Test):
         server.current_test = self
         execs = server.prepare_args()
         proc = Popen(execs, cwd=server.vardir, stdout=PIPE, stderr=STDOUT)
+        sampler.register_process(proc.pid, self.id, server.name)
         sys.stdout.write_bytes(proc.communicate()[0])
 
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -233,6 +233,25 @@ def format_process(pid):
     return 'process %d [%s; %s]' % (pid, status, cmdline)
 
 
+def proc_stat_rss_supported():
+    return os.path.isfile('/proc/%d/status' % os.getpid())
+
+
+def get_proc_stat_rss(pid):
+    rss = 0
+    try:
+        with open('/proc/%d/status' % pid, 'r') as f:
+            for line in f:
+                if ':' not in line:
+                    continue
+                key, value = line.split(':', 1)
+                if key == 'VmRSS':
+                    rss = int(value.strip().split()[0])
+    except (OSError, IOError):
+        pass
+    return rss
+
+
 def set_fd_cloexec(socket):
     flags = fcntl.fcntl(socket, fcntl.F_GETFD)
     fcntl.fcntl(socket, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)

--- a/lib/worker.py
+++ b/lib/worker.py
@@ -145,14 +145,16 @@ class WorkerTaskResult(BaseWorkerMessage):
     the task processed successfully or not, but with little more flexibility
     than binary True/False. The result_checksum (string) field saves the results
     file checksum on test fail. The task_id (any hashable object) field hold ID of
-    the processed task. The show_reproduce_content configuration form suite.ini
+    the processed task. The is_long (boolean) field shows if task is in long test
+    list in suite.ini. The show_reproduce_content configuration from suite.ini.
     """
     def __init__(self, worker_id, worker_name, task_id,
-                 short_status, result_checksum, show_reproduce_content):
+                 short_status, result_checksum, is_long, show_reproduce_content):
         super(WorkerTaskResult, self).__init__(worker_id, worker_name)
         self.short_status = short_status
         self.result_checksum = result_checksum
         self.task_id = task_id
+        self.is_long = is_long
         self.show_reproduce_content = show_reproduce_content
 
 
@@ -221,6 +223,7 @@ class Worker:
     def wrap_result(self, task_id, short_status, result_checksum):
         return WorkerTaskResult(self.id, self.name, task_id, short_status,
                                 result_checksum,
+                                self.suite.test_is_long(task_id),
                                 self.suite.show_reproduce_content())
 
     def sigterm_handler(self, signum, frame):


### PR DESCRIPTION
Patch set consists of 3 commits:

1. sampler: add simple sampling infrastructure
    
Track tarantool and unit test executables that are run using test-run
with metainformation: worker, test, test configuration and server name.
    
Add a function that will be called each 0.1 second for each tracked
process.
    
The implementation tracks non-default servers and re-register default
servers that executes several tests ('core = tarantool' case).
    
Part of #277

2. Add RSS statistics collecting.

Found that some tests may fail due to lack of memory. Mostly it happens
in CI on remote hosts. To be able to collect memory used statistic
decided to add RSS memory status collecting routine get_proc_stat_rss()
which parses files:
```
      /proc/<worker pid>/status
```
for RSS value 'VmRSS' which is size of memory portions. It contains the
three following parts (VmRSS = RssAnon + RssFile + RssShmem) [1]:
```
      RssAnon - size of resident anonymous memory
      RssFile - size of resident file mappings
      RssShmem - size of resident shmem memory (includes SysV shm, mapping of
                 tmpfs and shared anonymous mappings)
```
Decided that the best way for CI not to run this RSS collecting routine
for each sent command from tests tasks, but to run it after the test
task started each 0.1 second delay, to collect its maximum RSS value
during task run. This delay used to run routines in 'SamplerWatcher'
listener. Also found that delay of 0.1 sec is completely enough to catch
RSS use increase, due to tested check:
```
      tarantool> require('clock').bench(function() local t = {} for i = 1, 1024^2 * 100 do t[i] = true end end)
```
Which checked that 100 Mb of data allocated in seconds:
```
      - on CI test host: 3.153877479
      - on local fast host: 0.54504489
```
The main idea is to check all test depend processes running at some
point in time and choose maximum RSS reached value by it. For it used
'_sample_process()' routine which gets RSS for each currently alive
process and '_sample()' routine which counts sum of each task alive
processes RSS and checks if this value is bigger than previously
saved for the current task. Both routines are in 'Sampler()' class
which is called by 'process_timeout()' routine from 'SamplerWatcher'
listener.

Also used print_statistics() routine in listener 'StatisticsWatcher'
which prints statistics to stdout after testing. It used to print
RSS usage for failed tasks and up to 10 most used it tasks. Created
new subdirectory 'statistics' in 'vardir' path to save statistics
files. The current patch uses it to save there 'rss.log' file with
RSS values per tested tasks in format:
```
      <test task name> <maximum RSS value>
```
Closes #277

[1]: https://www.kernel.org/doc/html/latest/filesystems/proc.html

3. Add tests duration collecting

Decided to collect tests run durations in standalone file and print to
stdout after testing finished. To stdout printing durations for failed
tasks and up to 10 most long tasks.

For durations collecting used listener 'StatisticsWatcher' which has
the following used routines:
```
      process_result()
        Using 'WorkerTaskResult' queue message to collect tasks that failed
        and final durations for finished tasks. Durations collecting routine
        added in the worker running tests. Its values using 'result_queue'
        passing through 'WorkerTaskResult' queue message into the listener.
    
      print_statistics() - statistics printing to stdout after testing.
        Prints durations for failed tasks and up to 10 most long tasks.
        We use standalone 'statistics' directory in 'vardir' path to save
        'durations.log' file with durations for each tested tasks in format:
    
          <test task name> <float duration in secs with 2 digits after point>
```
Closes #286
