### PR TITLE
Add release_disabled field to app- and unit- tests

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -5,6 +5,7 @@ import shutil
 from lib.options import Options
 from lib.tarantool_server import TarantoolServer
 from lib.unittest_server import UnittestServer
+from lib.app_server import AppServer
 from lib.utils import warn_unix_sockets_at_start
 
 
@@ -62,6 +63,7 @@ def module_init():
 
     TarantoolServer.find_exe(args.builddir)
     UnittestServer.find_exe(args.builddir)
+    AppServer.find_exe(args.builddir)
 
     Options().check_schema_upgrade_option(TarantoolServer.debug)
 

--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -1,6 +1,7 @@
 import errno
 import glob
 import os
+import re
 import shutil
 import signal
 import sys
@@ -107,11 +108,9 @@ class AppServer(Server):
         self.testdir = os.path.abspath(os.curdir)
         self.vardir = ini['vardir']
         self.builddir = ini['builddir']
-        self.debug = False
         self.lua_libs = ini['lua_libs']
         self.name = 'app_server'
         self.process = None
-        self.binary = TarantoolServer.binary
         self.use_unix_sockets_iproto = ini['use_unix_sockets_iproto']
 
     @property
@@ -222,6 +221,9 @@ class AppServer(Server):
     @classmethod
     def find_exe(cls, builddir):
         cls.builddir = builddir
+        cls.binary = TarantoolServer.binary
+        cls.debug = bool(re.findall(r'-Debug', str(cls.version()),
+                                    re.I))
 
     @staticmethod
     def find_tests(test_suite, suite_path):

--- a/lib/server.py
+++ b/lib/server.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import shutil
+import subprocess
 from itertools import product
 
 from lib.server_mixins import ValgrindMixin
@@ -12,7 +13,7 @@ from lib.server_mixins import LuacovMixin
 from lib.colorer import color_stdout
 from lib.options import Options
 from lib.utils import print_tail_n
-
+from lib.utils import bytes_to_str
 
 DEFAULT_CHECKPOINT_PATTERNS = ["*.snap", "*.xlog", "*.vylog", "*.inprogress",
                                "[0-9]*/"]
@@ -103,6 +104,13 @@ class Server(object):
         # Used in valgrind_log property. 'test_suite' is not None only for
         # default servers running in TestSuite.run_all()
         self.test_suite = test_suite
+
+    @classmethod
+    def version(cls):
+        p = subprocess.Popen([cls.binary, "--version"], stdout=subprocess.PIPE)
+        version = bytes_to_str(p.stdout.read()).rstrip()
+        p.wait()
+        return version
 
     def prepare_args(self, args=[]):
         return args

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -659,13 +659,6 @@ class TarantoolServer(Server):
             self.current_test = caller_globals['test_run_current_test']
 
     @classmethod
-    def version(cls):
-        p = subprocess.Popen([cls.binary, "--version"], stdout=subprocess.PIPE)
-        version = bytes_to_str(p.stdout.read()).rstrip()
-        p.wait()
-        return version
-
-    @classmethod
     def find_exe(cls, builddir, silent=True):
         cls.builddir = os.path.abspath(builddir)
         builddir = os.path.join(builddir, "src")

--- a/lib/unittest_server.py
+++ b/lib/unittest_server.py
@@ -1,10 +1,12 @@
 import os
+import re
 import sys
 import glob
 from subprocess import Popen, PIPE, STDOUT
 
 from lib.server import Server
 from lib.tarantool_server import Test
+from lib.tarantool_server import TarantoolServer
 
 
 class UnitTest(Test):
@@ -34,7 +36,6 @@ class UnittestServer(Server):
         self.testdir = os.path.abspath(os.curdir)
         self.vardir = ini['vardir']
         self.builddir = ini['builddir']
-        self.debug = False
         self.name = 'unittest_server'
 
     @property
@@ -58,6 +59,9 @@ class UnittestServer(Server):
     @classmethod
     def find_exe(cls, builddir):
         cls.builddir = builddir
+        cls.binary = TarantoolServer.binary
+        cls.debug = bool(re.findall(r'-Debug', str(cls.version()),
+                                    re.I))
 
     @staticmethod
     def find_tests(test_suite, suite_path):


### PR DESCRIPTION
Previously if suite.ini has a release_disabled field it works only for
tarantool tests. This commit allows to use it for app- and unittests
suites.

Despite unittest does not take tarantool binary, unittests get version
(release/debug) from the tarantool binary information.

For instance,

Add line to test-unit/suite.ini:
`release_disabled = broken_unicode.test`

On debug version:
`[001] test-unit/broken_unicode.test                                   [ pass ]`

On release version:
`[001] test-unit/broken_unicode.test                                   [ disabled ]`

Closes: #199