### PR TITLE
Fix wrong condition in wait_until_started

### DIFF
--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -1119,7 +1119,7 @@ class TarantoolServer(Server):
                     color_log(" | Started {} (box.info.status: '{}')\n".format(
                         format_process(self.process.pid), ans))
                     return True
-                elif ans in ('loading'):
+                elif ans in ('loading',):
                     continue
                 else:
                     raise Exception(


### PR DESCRIPTION
Was fixed check that the answer is equal to `'loading'`. There was a
wrong condition and any substring of `'loading'` seemed like a correct
and equal to it.

One element tuple in python is defined as `(element,)`, without
a comma is a string.

Closes: #301