### PR TITLE
test_run:wait_log - drop redundant assert

### DIFF
--- a/test_run.lua
+++ b/test_run.lua
@@ -426,8 +426,6 @@ end
 -- Wrapper for grep_log, wait until expected log entry is appear
 -- in a server log file.
 local function wait_log(self, node, what, bytes, timeout, opts)
-    assert(timeout ~= nil)
-
     local opts = opts or {}
     local delay = opts.delay
 


### PR DESCRIPTION
The callee wait_cond does setup timeout by self in case if not provided

```lua
local function wait_cond(self, cond, timeout, delay)
    ...
    local timeout = timeout or 60
    ...
end

local function wait_log(self, node, what, bytes, timeout, opts)
    ...
    return wait_cond(self, cond, timeout, delay)
end
```

so no need to verify if timeout is provided in wait_log args.

@Totktonada: The wait_cond() and wait_log() helpers were added in [1] without a
default timeout: so they assert that a caller provides it. Later, in [2], the
default timeout was added for wait_cond(). Here we forgot to drop the assertion
from wait_log().

[1]: 670f330aacaf44bc8b1f969fa0cd5f811c5ceb1b ('test: wait for logs')
[2]: fe9ca2e768f3773a57d5cb905adaec931b0cb275 ('Add default timeout for wait_cond routine')

Signed-off-by: Cyrill Gorcunov \<gorcunov@gmail.com\>