### PR TITLE
pretest_clean: add SQL built-in function UUID()

### DIFF
--- a/pretest_clean.lua
+++ b/pretest_clean.lua
@@ -135,6 +135,7 @@ local function clean()
         ['_sql_stat_push'] = true,
         ['_sql_stat_init'] = true,
         ['LUA'] = true,
+        ['UUID'] = true,
     }
     box.space._func:pairs():map(function(tuple)
         local name = tuple[_FUNC_NAME]


### PR DESCRIPTION
This patch adds the built-in SQL function UUID() to the list of allowed
functions. This function is described in RFC "Consistent Lua/SQL types"
and will be added as part of issue tarantool/tarantool#5886.

Needed for tarantool/tarantool#5886.