### PR TITLE
Decrease unix socket filename length

### DIFF
--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -154,7 +154,7 @@ class AppServer(Server):
                         continue
                     raise
         if self.use_unix_sockets_iproto:
-            path = os.path.join(self.vardir, self.name + ".socket-iproto")
+            path = os.path.join(self.vardir, self.name + ".i")
             warn_unix_socket(path)
             self.iproto = path
         else:

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -718,14 +718,14 @@ class TarantoolServer(Server):
         self.copy_files()
 
         if self.use_unix_sockets:
-            path = os.path.join(self.vardir, self.name + ".socket-admin")
+            path = os.path.join(self.vardir, self.name + ".c")
             warn_unix_socket(path)
             self._admin = path
         else:
             self._admin = find_port()
 
         if self.use_unix_sockets_iproto:
-            path = os.path.join(self.vardir, self.name + ".socket-iproto")
+            path = os.path.join(self.vardir, self.name + ".i")
             warn_unix_socket(path)
             self._iproto = path
         else:

--- a/listeners.py
+++ b/listeners.py
@@ -221,7 +221,7 @@ class ArtifactsWatcher(BaseWatcher):
             shutil.copytree(os.path.join(vardir, worker_name),
                             os.path.join(artifacts_dir, worker_name),
                             ignore=shutil.ignore_patterns(
-                                '*.socket-iproto', '*.socket-admin',
+                                '*.i', '*.c',
                                 '*.sock', '*.control'))
         shutil.copytree(os.path.join(vardir, 'statistics'),
                         os.path.join(artifacts_dir, 'statistics'))


### PR DESCRIPTION
See https://github.com/tarantool/tarantool/pull/6365 for details about
possible problems and the description how it occurs.

We're going to use tags like 2.10.0-beta1 and so the build directory
path under rpmbuild will be even longer than before. So we should
decrease the absolute path length of a unix socket and so it worth to
trim the basename.

Of course, sooner or later we should elaborate a full solution.