### PR TITLE
Support tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,55 @@ The following files will be removed:
 * `*.inprogress`
 * `[0-9]*/`
 
+### Tags
+
+Usage:
+
+```sh
+./test-run.py --tags foo
+./test-run.py --tags foo,bar app/ app-tap/
+```
+
+test-run will run only those tests, which have at least one of the
+provided tags.
+
+The tags metainfo should be placed within a first comment of a test
+file.
+
+Examples:
+
+* .lua file:
+
+  ```lua
+  #!/usr/bin/tarantool
+
+  -- tags: foo, bar
+  -- tags: one, more
+
+  <...>
+  ```
+
+* .sql file:
+
+  ```sql
+  -- tags: foo
+  -- tags: bar
+  <...>
+  ```
+
+* .py file:
+
+  ```python
+  # tags: foo
+
+  <...>
+  ```
+
+Unsupported features:
+
+* Marking unit tests with tags.
+* Multiline comments (use singleline ones for now).
+
 ### Used By
 
 - [Tarantool](https://github.com/tarantool/tarantool) - in-memory database and application server

--- a/README.md
+++ b/README.md
@@ -365,6 +365,13 @@ Usage:
 test-run will run only those tests, which have at least one of the
 provided tags.
 
+Show a list of tags:
+
+```sh
+./test-run.py --tags
+./test-run.py app-tap/ --tags
+```
+
 The tags metainfo should be placed within a first comment of a test
 file.
 

--- a/lib/options.py
+++ b/lib/options.py
@@ -35,6 +35,9 @@ class Options(object):
     _instance = None
     _initialized = False
 
+    # Just some unique marker.
+    _show_tags = {}
+
     def __new__(cls, *args, **kwargs):
         """Make the class singleton."""
         if cls._instance:
@@ -280,6 +283,8 @@ class Options(object):
         parser.add_argument(
                 '--tags',
                 dest='tags',
+                const=self._show_tags,
+                nargs='?',
                 default=None,
                 type=split_list,
                 help="""Comma separated list of tags.
@@ -287,12 +292,28 @@ class Options(object):
                 If tags are provided, test-run will run only those
                 tests, which are marked with ANY of the provided
                 tags.
+
+                If the option is given without a parameter (at the
+                last position), test-run will show a list of tags
+                and stop.
                 """)
 
         # XXX: We can use parser.parse_intermixed_args() on
         # Python 3.7 to understand commands like
         # ./test-run.py foo --exclude bar baz
         self.args = parser.parse_args()
+
+        # If `--tags foo,bar` is passed, just keep the list in
+        # `args.tags`.
+        #
+        # If `--tags` is passed without a parameter, clean up
+        # `args.tags` and toggle `args.show_tags`.
+        if self.args.tags == self._show_tags:
+            self.args.tags = None
+            self.args.show_tags = True
+        else:
+            self.args.show_tags = False
+
         self.check()
 
         Options._initialized = True

--- a/lib/options.py
+++ b/lib/options.py
@@ -22,6 +22,13 @@ def env_list(name, default):
     return value_list or default
 
 
+def split_list(tags_str):
+    # Accept both ', ' and ',' as a separator.
+    #
+    # It is consistent with parsing of tags within a test file.
+    return [tag.strip() for tag in tags_str.split(',')]
+
+
 class Options(object):
     """Handle options of test-runner"""
 
@@ -270,6 +277,17 @@ class Options(object):
                 dest="memtx_allocator",
                 default=os.environ.get("MEMTX_ALLOCATOR", "small"),
                 help="""Memtx allocator type for tests""")
+        parser.add_argument(
+                '--tags',
+                dest='tags',
+                default=None,
+                type=split_list,
+                help="""Comma separated list of tags.
+
+                If tags are provided, test-run will run only those
+                tests, which are marked with ANY of the provided
+                tags.
+                """)
 
         # XXX: We can use parser.parse_intermixed_args() on
         # Python 3.7 to understand commands like

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -76,6 +76,7 @@ class LuaTest(Test):
     RESULT_FILE_VERSION_LINE_RE = re.compile(
         r'^-- test-run result file version (?P<version>\d+)$')
     RESULT_FILE_VERSION_TEMPLATE = '-- test-run result file version {}'
+    TAGS_LINE_RE = re.compile(r'^-- tags:')
 
     def __init__(self, *args, **kwargs):
         super(LuaTest, self).__init__(*args, **kwargs)
@@ -250,6 +251,16 @@ class LuaTest(Test):
         for line in open(self.name, 'r'):
             # Normalize a line.
             line = line.rstrip('\n')
+
+            # Skip metainformation (only tags at the moment).
+            #
+            # It is to reduce noise changes in result files, when
+            # tags are added or edited.
+            #
+            # TODO: Ideally we should do that only on a first
+            # comment in the file.
+            if self.TAGS_LINE_RE.match(line):
+                continue
 
             # Show empty lines / comments in a result file, but
             # don't send them to tarantool.

--- a/lib/test_suite.py
+++ b/lib/test_suite.py
@@ -164,7 +164,8 @@ class TestSuite:
         else:
             raise ValueError('Cannot collect tests of unknown type')
 
-        if not Options().args.reproduce:
+        # In given cases, this large output looks redundant.
+        if not Options().args.reproduce and not Options().args.show_tags:
             color_stdout("Collecting tests in ", schema='ts_text')
             color_stdout(
                 '%s (Found %s tests)' % (

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -376,3 +376,37 @@ def str_to_bytes(s):
     if PY2:
         return s
     return s.encode('utf-8')
+
+
+def parse_tag_line(line):
+    tags_str = line.split(':', 1)[1].strip()
+    return [tag.strip() for tag in tags_str.split(',')]
+
+
+def find_tags(filename):
+    """ Extract tags from a first comment in the file.
+    """
+    # TODO: Support multiline comments. See exclude_tests() in
+    # lib/server.py.
+    if filename.endswith('.lua') or filename.endswith('.sql'):
+        singleline_comment = '--'
+    elif filename.endswith('.py'):
+        singleline_comment = '#'
+    else:
+        return []
+
+    tags = []
+    with open(filename, 'r') as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if line.startswith('#!'):
+                pass
+            elif line == '':
+                pass
+            elif line.startswith(singleline_comment + ' tags:'):
+                tags.extend(parse_tag_line(line))
+            elif line.startswith(singleline_comment):
+                pass
+            else:
+                break
+    return tags

--- a/test-run.py
+++ b/test-run.py
@@ -55,6 +55,7 @@ import time
 
 from lib import Options
 from lib.colorer import color_stdout
+from lib.utils import find_tags
 from lib.utils import print_tail_n
 from lib.utils import PY3
 from lib.worker import get_task_groups
@@ -221,6 +222,19 @@ def main_consistent():
     return (-1 if failed_test_ids else 0)
 
 
+def show_tags():
+    # Collect tests in the same way as when we run them.
+    collected_tags = set()
+    for name, task_group in get_task_groups().items():
+        for task_id in task_group['task_ids']:
+            test_name, _ = task_id
+            for tag in find_tags(test_name):
+                collected_tags.add(tag)
+
+    for tag in sorted(collected_tags):
+        color_stdout(tag + '\n')
+
+
 if __name__ == "__main__":
     # In Python 3 start method 'spawn' in multiprocessing module becomes
     # default on Mac OS.
@@ -274,6 +288,10 @@ if __name__ == "__main__":
     os.environ['OMP_NUM_THREADS'] = '2'
 
     status = 0
+
+    if Options().args.show_tags:
+        show_tags()
+        exit(status)
 
     force_parallel = bool(Options().args.reproduce)
     if not force_parallel and Options().args.jobs == -1:


### PR DESCRIPTION
Usage:

```sh
./test-run.py --tags foo
./test-run.py --tags foo,bar app/ app-tap/
```

test-run will run only those tests, which have at least one of the
provided tags.

Show a list of tags:

```sh
./test-run.py --tags
./test-run.py app-tap/ --tags
```

The tags metainfo should be placed within a first comment of a test
file.

Examples:

* .lua file:

  ```lua
  #!/usr/bin/tarantool

  -- tags: foo, bar
  -- tags: one, more

  <...>
  ```

* .sql file:

  ```sql
  -- tags: foo
  -- tags: bar
  <...>
  ```

* .py file:

  ```python
  # tags: foo

  <...>
  ```

Unsupported features:

* Marking unit tests with tags.
* Multiline comments (use singleline ones for now).

Fixes #22