### PR TITLE
Enable parallel invocation of fragile tests

### DIFF
--- a/lib/worker.py
+++ b/lib/worker.py
@@ -89,7 +89,7 @@ def get_task_groups():
             res[key + '_fragile'] = {
                 'gen_worker': gen_worker,
                 'task_ids': fragile_task_ids,
-                'is_parallel': False,
+                'is_parallel': suite.is_parallel(),
                 'show_reproduce_content': suite.show_reproduce_content(),
             }
     return res


### PR DESCRIPTION
This will speed up tarantool/tarantool testing about 3 times.