### PR TITLE
Add an option to show test-run's environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ and a number of fields:
 
 Field `core` must be one of:
 
+* `luatest` - [luatest][luatest] compatible test suite
 * `tarantool` - Test-Suite for Functional Testing
 * `app` - Another functional Test-Suite
 * `unittest` - Unit-Testing Test Suite
@@ -409,9 +410,36 @@ Unsupported features:
 * Marking unit tests with tags.
 * Multiline comments (use singleline ones for now).
 
+### Using luatest
+
+test-run supports tests written in the [luatest][luatest] format. `*_test.lua`
+files in a `core = luatest` test suite are run as part of `./test/test-run.py`
+invocation: no extra actions are needed.
+
+You can also run a particular test using a substring of its full name:
+
+```shell
+$ ./test/test-run.py foo-luatest/bar_test.lua
+$ ./test/test-run.py bar_test.lua
+$ ./test/test-run.py bar
+```
+
+If you need to run a particular test case from a luatest compatible test, use
+`luatest` command directly. In order to use luatest, which is bundled into
+test-run, source test-run's environment:
+
+```shell
+$ . <(./test/test-run.py --env)
+$ luatest -v -p my_specific_test_case
+```
+
 ### Used By
 
 - [Tarantool](https://github.com/tarantool/tarantool) - in-memory database and application server
 - [memcached](https://github.com/tarantool/memcached) - Memcached protocol 'wrapper' for Tarantool
 - [vshard](https://github.com/tarantool/vshard) - sharding based on virtual buckets
 - xsync (internal project)
+
+<!-- References -->
+
+[luatest]: https://github.com/tarantool/luatest

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -70,8 +70,9 @@ def module_init():
     os.environ["REPLICATION_SYNC_TIMEOUT"] = str(args.replication_sync_timeout)
     os.environ['MEMTX_ALLOCATOR'] = args.memtx_allocator
 
-    os.environ['LUATEST_BIN'] = os.path.join(
-        os.environ['TEST_RUN_DIR'], 'lib/luatest/bin/luatest')
+    luatest_bin_dir = os.path.join(os.environ['TEST_RUN_DIR'],
+                                   'lib/luatest/bin')
+    os.environ['PATH'] = ':'.join((luatest_bin_dir, os.environ['PATH']))
 
     TarantoolServer.find_exe(args.builddir)
     UnittestServer.find_exe(args.builddir)

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -8,6 +8,7 @@ from lib.unittest_server import UnittestServer
 from lib.app_server import AppServer
 from lib.luatest_server import LuatestServer
 from lib.utils import warn_unix_sockets_at_start
+from lib.utils import prepend_path
 
 
 __all__ = ['Options']
@@ -70,9 +71,7 @@ def module_init():
     os.environ["REPLICATION_SYNC_TIMEOUT"] = str(args.replication_sync_timeout)
     os.environ['MEMTX_ALLOCATOR'] = args.memtx_allocator
 
-    luatest_bin_dir = os.path.join(os.environ['TEST_RUN_DIR'],
-                                   'lib/luatest/bin')
-    os.environ['PATH'] = ':'.join((luatest_bin_dir, os.environ['PATH']))
+    prepend_path(os.path.join(os.environ['TEST_RUN_DIR'], 'lib/luatest/bin'))
 
     TarantoolServer.find_exe(args.builddir)
     UnittestServer.find_exe(args.builddir)

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -11,7 +11,7 @@ from lib.utils import warn_unix_sockets_at_start
 from lib.utils import prepend_path
 
 
-__all__ = ['Options']
+__all__ = ['Options', 'saved_env']
 
 
 def setenv():
@@ -25,8 +25,18 @@ def setenv():
         path = os.path.abspath(os.path.join(path, '../'))
 
 
+_saved_env = None
+
+
+def saved_env():
+    return _saved_env
+
+
 def module_init():
     """ Called at import """
+    global _saved_env
+    _saved_env = dict(os.environ)
+
     args = Options().args
     # Change the current working directory to where all test
     # collections are supposed to reside

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -20,7 +20,7 @@ def setenv():
     path = os.path.abspath('../')
     while path != '/':
         if os.path.isfile('%s/%s' % (path, check_file)):
-            os.putenv('TARANTOOL_SRC_DIR', path)
+            os.environ['TARANTOOL_SRC_DIR'] = path
             break
         path = os.path.abspath(os.path.join(path, '../'))
 

--- a/lib/luatest_server.py
+++ b/lib/luatest_server.py
@@ -34,8 +34,8 @@ class LuatestTest(Test):
         """
         server.current_test = self
         script = os.path.join(os.path.basename(server.testdir), self.name)
-        command = [os.environ['LUATEST_BIN'], '-c', '-v', script, '-o', 'tap',
-                   '--shuffle', 'none']
+        command = ['luatest', '-c', '-v', script, '-o', 'tap', '--shuffle',
+                   'none']
 
         # Tarantool's build directory is added to PATH in
         # TarantoolServer.find_exe().
@@ -99,7 +99,7 @@ class LuatestServer(Server):
         try:
             # Just check that the command returns zero exit code.
             with open(os.devnull, 'w') as devnull:
-                returncode = Popen([os.environ['LUATEST_BIN'], '--version'],
+                returncode = Popen(['luatest', '--version'],
                                    stdout=devnull,
                                    stderr=devnull).wait()
             if returncode != 0:

--- a/lib/options.py
+++ b/lib/options.py
@@ -297,6 +297,21 @@ class Options(object):
                 last position), test-run will show a list of tags
                 and stop.
                 """)
+        parser.add_argument(
+                '--env',
+                dest='show_env',
+                action='store_true',
+                default=False,
+                help="""Print environment variables, which are set by test-run.
+
+                Useful for, say, running built-in luatest executable.
+
+                Usage: just source it into a current environment:
+
+                ```
+                . <(./test/test-run.py --env)
+                ```
+                """)
 
         # XXX: We can use parser.parse_intermixed_args() on
         # Python 3.7 to understand commands like

--- a/lib/server_mixins.py
+++ b/lib/server_mixins.py
@@ -2,16 +2,10 @@ import os
 import glob
 import shlex
 
-try:
-    # Python 3.3+.
-    from shlex import quote as shlex_quote
-except ImportError:
-    # Python 2.7.
-    from pipes import quote as shlex_quote
-
 from lib.utils import find_in_path
 from lib.utils import print_tail_n
 from lib.utils import non_empty_valgrind_logs
+from lib.utils import shlex_quote
 from lib.colorer import color_log
 from lib.colorer import color_stdout
 

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -44,6 +44,7 @@ from lib.utils import safe_makedirs
 from lib.utils import signame
 from lib.utils import warn_unix_socket
 from lib.utils import prefix_each_line
+from lib.utils import prepend_path
 from lib.test import TestRunGreenlet, TestExecutionError
 
 
@@ -683,11 +684,8 @@ class TarantoolServer(Server):
                 cls.ctl_plugins = os.path.abspath(
                     os.path.join(ctl_dir, '..')
                 )
-                os.environ["PATH"] = os.pathsep.join([
-                    os.path.abspath(ctl_dir),
-                    os.path.abspath(_dir),
-                    os.environ["PATH"]
-                ])
+                prepend_path(ctl_dir)
+                prepend_path(_dir)
                 os.environ["TARANTOOLCTL"] = ctl
                 if need_lua_path:
                     os.environ["LUA_PATH"] = \

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -410,3 +410,12 @@ def find_tags(filename):
             else:
                 break
     return tags
+
+
+def prepend_path(p):
+    """ Add an absolute path into PATH (at start) if it is not already there.
+    """
+    p = os.path.abspath(p)
+    if p in os.environ['PATH'].split(os.pathsep):
+        return
+    os.environ['PATH'] = os.pathsep.join((p, os.environ['PATH']))

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -11,12 +11,20 @@ import json
 import subprocess
 from gevent import socket
 from lib.colorer import color_stdout
+
 try:
     # Python3.5 or above
     from signal import Signals
 except ImportError:
     # Python2
     Signals = None
+
+try:
+    # Python 3.3+.
+    from shlex import quote as _shlex_quote
+except ImportError:
+    # Python 2.7.
+    from pipes import quote as _shlex_quote
 
 
 UNIX_SOCKET_LEN_LIMIT = 107
@@ -419,3 +427,7 @@ def prepend_path(p):
     if p in os.environ['PATH'].split(os.pathsep):
         return
     os.environ['PATH'] = os.pathsep.join((p, os.environ['PATH']))
+
+
+def shlex_quote(s):
+    return _shlex_quote(s)


### PR DESCRIPTION
Usage:

```shell
$ . <(./test/test-run.py --env)
```

(Or copy-paste `./test/test-run.py --env` output into a shell.)

test-run ships luatest sources, but it is tricky to use it directly, because it requires to set appropriate `LUA_PATH`.

The new option prints all environment variables, which test-run sets at initialization, including `PATH` and `LUA_PATH`. The variables are printed in the format suitable for sourcing into a shell.

So now it is easy to call something like `luatest -v -p test_case_name`.

Fixes #325.