### PR TITLE
Rerun all failed tests, not only marked as fragile

### DIFF
--- a/lib/test_suite.py
+++ b/lib/test_suite.py
@@ -45,6 +45,9 @@ class TestSuite:
     server for this suite, the client program to execute individual
     tests and other suite properties. The server is started once per
     suite."""
+
+    RETRIES_COUNT = 3
+
     def get_multirun_conf(self, suite_path):
         conf_name = self.ini.get('config', None)
         if conf_name is None:
@@ -91,7 +94,7 @@ class TestSuite:
         self.args = args
         self.tests = []
         self.ini = {}
-        self.fragile = {'retries': 0, 'tests': {}}
+        self.fragile = {'retries': self.RETRIES_COUNT, 'tests': {}}
         self.suite_path = suite_path
         self.ini["core"] = "tarantool"
 
@@ -128,7 +131,7 @@ class TestSuite:
         if config.has_option("default", "fragile"):
             fragiles = config.get("default", "fragile")
             try:
-                self.fragile = json.loads(fragiles)
+                self.fragile.update(json.loads(fragiles))
                 if 'tests' not in self.fragile:
                     raise RuntimeError(
                         "Key 'tests' absent in 'fragile' json: {}"
@@ -288,7 +291,7 @@ class TestSuite:
         return self.ini['is_parallel']
 
     def fragile_retries(self):
-        return self.fragile.get('retries', 0)
+        return self.fragile['retries']
 
     def show_reproduce_content(self):
         return self.ini['show_reproduce_content']


### PR DESCRIPTION
test-run supports functionality to rerun failed tests in place, but
these tests have to be on so called fragile list. To add a test to the
fragile list we need to add a special configuration to the suite.ini
file of a test suite. Configuration example:

    fragile = {
        "retries": 5,
        "tests": {
            "tarantoolctl.test.lua": {
                "issues": [ "gh-5059", "gh-5346" ]
            },
            "debug.test.lua": {
                "issues": [ "gh-5346" ]
            },
            ...
        }
    }

Rerunning failed tests in place is quite convenient because it allows us
to avoid rerunning all tests again and thus save time.

But to make it work as expected we should keep the list of fragile tests
always up-to-date. Flaky tests may be introduced every day and keeping
the list of fragile tests always up-to-date becomes extremely difficult
to do.

So our solusion is quite simple: just rerun all failed tests.
By default, the number of retries for regular and fragile tests is 3.
But for fragile tests this number can be overriden in the suite.ini
file.

Closes #328