### PR TITLE
Kill hanging processes of not started servers (reworked fix)

### DIFF
--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -1016,7 +1016,7 @@ class TarantoolServer(Server):
             color_log('Server [%s] start against running ...\n',
                       schema='test_var')
             return
-        if self.status != 'started':
+        if self.status != 'started' and not hasattr(self, 'process'):
             if not silent:
                 raise Exception('Server is not started')
             else:

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -1016,6 +1016,16 @@ class TarantoolServer(Server):
             color_log('Server [%s] start against running ...\n',
                       schema='test_var')
             return
+        if self.status != 'started':
+            if not silent:
+                raise Exception('Server is not started')
+            else:
+                color_log(
+                    'Server [{0.name}] is not started '
+                    '(status:{0.status}) ...\n'.format(self),
+                    schema='test_var'
+                )
+            return
         if not silent:
             color_stdout('[Instance {}] Stopping the server...\n'.format(
                 self.name), schema='info')


### PR DESCRIPTION
This change reverts the previous fix (because it was wrong) and 
provides the proper solution of the issue. 

It was found that hanging processes of not started tarantool servers
are not killed by test-run and leave to hang. This situation can be
reproduced by creating the main server, then creating a replica server,
but the replica server is unable to join the master, for example, due
to lack of user permissions. In this case, the test fails by the server
start timeout and test-run kills the main server process only.
This patch fixes the issue.

Fixes #256
Follows #276