### PR TITLE
Add option to tune test run retries after failure

### DIFF
--- a/lib/options.py
+++ b/lib/options.py
@@ -208,10 +208,10 @@ class Options(object):
         parser.add_argument(
                 "-r", "--retries",
                 dest='retries',
-                default=env_int('TEST_RUN_RETRIES', 3),
+                default=env_int('TEST_RUN_RETRIES', 0),
                 type=int,
                 help="""The number of test run retries after a failure.
-                Default: ${TEST_RUN_RETRIES} or 3. It is also the default value
+                Default: ${TEST_RUN_RETRIES} or 0. It is also the default value
                 for 'fragile' tests unless the `retries` option is set in the
                 suite.ini config file.""")
 

--- a/lib/options.py
+++ b/lib/options.py
@@ -206,6 +206,16 @@ class Options(object):
                 (single process). """)
 
         parser.add_argument(
+                "-r", "--retries",
+                dest='retries',
+                default=env_int('TEST_RUN_RETRIES', 3),
+                type=int,
+                help="""The number of test run retries after a failure.
+                Default: ${TEST_RUN_RETRIES} or 3. It is also the default value
+                for 'fragile' tests unless the `retries` option is set in the
+                suite.ini config file.""")
+
+        parser.add_argument(
                 "--reproduce",
                 dest="reproduce",
                 default=None,

--- a/lib/test_suite.py
+++ b/lib/test_suite.py
@@ -46,7 +46,7 @@ class TestSuite:
     tests and other suite properties. The server is started once per
     suite."""
 
-    RETRIES_COUNT = 3
+    RETRIES_COUNT = Options().args.retries
 
     def get_multirun_conf(self, suite_path):
         conf_name = self.ini.get('config', None)


### PR DESCRIPTION
This change adds the --retries (-r) option for having a facility to tune
the number of test run retries after a failure. Besides regular tests,
it is also the default value for 'fragile' tests unless the `retries`
option is set in the suite.ini config file.

Also, it introduces the `TEST_RUN_RETRIES` env variable to tune retries
count via shell (useful for CI systems).

Closes #334