### PR TITLE
Change default value for vardir option 

### DIFF
--- a/lib/options.py
+++ b/lib/options.py
@@ -256,7 +256,7 @@ class Options(object):
         parser.add_argument(
                 "--vardir",
                 dest="vardir",
-                default="var",
+                default='/tmp/t',
                 help=format_help(
                     """
                     Path to data directory.
@@ -265,7 +265,7 @@ class Options(object):
                     where all tests reside. **NOT** a current directory of a
                     parent shell.
 
-                    Default: var.
+                    Default: /tmp/t.
                     """))
 
         parser.add_argument(

--- a/lib/options.py
+++ b/lib/options.py
@@ -256,7 +256,7 @@ class Options(object):
         parser.add_argument(
                 "--vardir",
                 dest="vardir",
-                default='/tmp/t',
+                default=os.environ.get('VARDIR') or '/tmp/t',
                 help=format_help(
                     """
                     Path to data directory.
@@ -265,7 +265,7 @@ class Options(object):
                     where all tests reside. **NOT** a current directory of a
                     parent shell.
 
-                    Default: /tmp/t.
+                    Default: ${VARDIR} or /tmp/t.
                     """))
 
         parser.add_argument(


### PR DESCRIPTION
Now the default value for the `vardir` option is `/tmp/t`. This change
should help to solve the issue with the max length of the socket paths
(107 chars) in most cases.

Also, the default value for the `vardir` option is taken from the `VARDIR`
env variable when it is defined.