### PR TITLE
Fail *.test.py tests in case of srv start errors

### DIFF
--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -402,7 +402,13 @@ class PythonTest(Test):
         new_globals = dict(locals(), test_run_current_test=self, **server.__dict__)
         with open(self.name) as f:
             code = compile(f.read(), self.name, 'exec')
+
+        try:
             exec(code, new_globals)
+        except TarantoolStartError:
+            # fail tests in the case of catching server start errors
+            raise TestExecutionError
+
         # crash was detected (possibly on non-default server)
         if server.current_test.is_crash_reported:
             raise TestExecutionError

--- a/lib/worker.py
+++ b/lib/worker.py
@@ -266,9 +266,9 @@ class Worker:
                          'the tasks will be ignored...\n' % self.name,
                          schema='error')
             color_stdout("The raised exception is '%s' of type '%s'.\n"
-                         % (str(e), str(type(e))), schema='error')
+                         % (str(e).strip(), str(type(e))), schema='error')
             color_stdout('Worker "%s" received the following error:\n'
-                         % self.name + traceback.format_exc() + '\n',
+                         % self.name + traceback.format_exc().strip() + '\n',
                          schema='error')
             self.stop_server(cleanup=False)
 


### PR DESCRIPTION
When a tarantool server failed to start when running *.test.py tests,
the corresponding test was not considered by test-run as a failed test.
As a result of that, log artifacts were not gathered by test-run. Now
it is fixed.

Fixes #333