### PR TITLE
Free port auto resolving for TarantoolServer and AppServer

### DIFF
--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -19,7 +19,6 @@ from lib.server import DEFAULT_SNAPSHOT_NAME
 from lib.tarantool_server import Test
 from lib.tarantool_server import TarantoolServer
 from lib.tarantool_server import TarantoolStartError
-from lib.utils import find_port
 from lib.utils import format_process
 from lib.utils import signame
 from lib.utils import warn_unix_socket
@@ -33,7 +32,7 @@ def timeout_handler(server_process, test_timeout):
 
 
 def run_server(execs, cwd, server, logfile, retval, test_id):
-    os.putenv("LISTEN", server.iproto)
+    os.putenv("LISTEN", server.listen_uri)
     server.process = Popen(execs, stdout=PIPE, stderr=PIPE, cwd=cwd)
     sampler.register_process(server.process.pid, test_id, server.name)
     test_timeout = Options().args.test_timeout
@@ -113,6 +112,7 @@ class AppServer(Server):
         self.lua_libs = ini['lua_libs']
         self.name = 'app_server'
         self.process = None
+        self.localhost = '127.0.0.1'
         self.use_unix_sockets_iproto = ini['use_unix_sockets_iproto']
 
     @property
@@ -156,9 +156,9 @@ class AppServer(Server):
         if self.use_unix_sockets_iproto:
             path = os.path.join(self.vardir, self.name + ".i")
             warn_unix_socket(path)
-            self.iproto = path
+            self.listen_uri = path
         else:
-            self.iproto = str(find_port())
+            self.listen_uri = self.localhost + ':0'
         shutil.copy(os.path.join(self.TEST_RUN_DIR, 'test_run.lua'),
                     self.vardir)
 

--- a/lib/box_connection.py
+++ b/lib/box_connection.py
@@ -23,12 +23,14 @@ __author__ = "Konstantin Osipov <kostja.osipov@gmail.com>"
 
 import errno
 import ctypes
+import re
 import socket
 
 from lib.tarantool_connection import TarantoolConnection
 
 # monkey patch tarantool and msgpack
 from lib.utils import check_libs
+from lib.utils import warn_unix_socket
 check_libs()
 
 from tarantool import Connection as tnt_connection  # noqa: E402
@@ -41,6 +43,10 @@ SEPARATOR = '\n'
 class BoxConnection(TarantoolConnection):
     def __init__(self, host, port):
         super(BoxConnection, self).__init__(host, port)
+        if self.host == 'unix/' or re.search(r'^/', str(self.port)):
+            warn_unix_socket(self.port)
+            host = None
+
         self.py_con = tnt_connection(host, port, connect_now=False,
                                      socket_timeout=100)
         self.py_con.error = False

--- a/lib/inspector.py
+++ b/lib/inspector.py
@@ -7,7 +7,6 @@ from gevent.lock import Semaphore
 from gevent.server import StreamServer
 
 from lib.utils import bytes_to_str
-from lib.utils import find_port
 from lib.utils import prefix_each_line
 from lib.utils import str_to_bytes
 from lib.colorer import color_stdout
@@ -52,10 +51,6 @@ class TarantoolInspector(StreamServer):
     """
 
     def __init__(self, host, port):
-        # When specific port range was acquired for current worker, don't allow
-        # OS set port for us that isn't from specified range.
-        if port == 0:
-            port = find_port()
         super(TarantoolInspector, self).__init__((host, port))
         self.parser = None
 

--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -59,7 +59,7 @@ class TestState(object):
             self.curcon = [self.connections['default']]
             nmsp = Namespace()
             setattr(nmsp, 'admin', default_server.admin.uri)
-            setattr(nmsp, 'listen', default_server.iproto.uri)
+            setattr(nmsp, 'listen', default_server.listen_uri)
             setattr(self.environ, 'default', nmsp)
         # for propagating 'current_test' to non-default servers
         self.default_server_no_connect = kwargs.get(
@@ -282,13 +282,13 @@ class TestState(object):
                 copy_to
             ))
         nmsp = Namespace()
-        setattr(nmsp, 'admin', temp.admin.port)
-        setattr(nmsp, 'listen', temp.iproto.port)
+        setattr(nmsp, 'admin', temp.admin.uri)
+        setattr(nmsp, 'listen', temp.listen_uri)
         if temp.rpl_master:
-            setattr(nmsp, 'master', temp.rpl_master.iproto.port)
+            setattr(nmsp, 'master', temp.rpl_master.iproto.uri)
         setattr(self.environ, sname, nmsp)
         if 'return_listen_uri' in opts and opts['return_listen_uri'] == 'True':
-            return self.servers[sname].iproto.uri
+            return self.servers[sname].listen_uri
 
     def server_deploy(self, ctype, sname, opts):
         self.servers[sname].install()
@@ -341,6 +341,9 @@ class TestState(object):
         finally:
             # remove proxy
             self.server_stop('stop', 'proxy', {})
+
+    def server_get_iproto_uri(self, ctype, sname, opts):
+        return self.servers[sname].iproto.uri
 
     def server(self, ctype, sname, opts):
         attr = 'server_%s' % ctype

--- a/lib/preprocessor.py
+++ b/lib/preprocessor.py
@@ -259,7 +259,6 @@ class TestState(object):
         if 'rpl_master' in opts:
             temp.rpl_master = self.servers[opts['rpl_master']]
         temp.vardir = self.suite_ini['vardir']
-        temp.use_unix_sockets = self.suite_ini['use_unix_sockets']
         temp.use_unix_sockets_iproto = \
             self.suite_ini['use_unix_sockets_iproto']
         temp.inspector_port = int(self.suite_ini.get(

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -10,6 +10,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import textwrap
 import time
 import yaml
 
@@ -655,12 +656,15 @@ class TarantoolServer(Server):
             'lua_libs': [],
             'valgrind': False,
             'vardir': None,
-            'use_unix_sockets': False,
             'use_unix_sockets_iproto': False,
             'tarantool_port': None,
             'strace': False
         }
         ini.update(_ini)
+        if ini.get('use_unix_sockets') is not None:
+            qa_notice(textwrap.fill('The "use_unix_sockets" option is defined '
+                                    'in suite.ini, but it was dropped in favor '
+                                    'of permanent using Unix sockets'))
         Server.__init__(self, ini, test_suite)
         self.testdir = os.path.abspath(os.curdir)
         self.sourcedir = os.path.abspath(os.path.join(os.path.basename(
@@ -677,7 +681,6 @@ class TarantoolServer(Server):
         self.lua_libs = ini['lua_libs']
         self.valgrind = ini['valgrind']
         self.strace = ini['strace']
-        self.use_unix_sockets = ini['use_unix_sockets']
         self.use_unix_sockets_iproto = ini['use_unix_sockets_iproto']
         self._start_against_running = ini['tarantool_port']
         self.crash_detector = None
@@ -762,12 +765,9 @@ class TarantoolServer(Server):
             self.cleanup()
         self.copy_files()
 
-        if self.use_unix_sockets:
-            path = os.path.join(self.vardir, self.name + ".c")
-            warn_unix_socket(path)
-            self._admin = path
-        else:
-            self._admin = find_port()
+        path = os.path.join(self.vardir, self.name + ".c")
+        warn_unix_socket(path)
+        self._admin = path
 
         if self.use_unix_sockets_iproto:
             path = os.path.join(self.vardir, self.name + ".i")

--- a/lib/test_suite.py
+++ b/lib/test_suite.py
@@ -140,7 +140,6 @@ class TestSuite:
                 # use old format dictionary
                 self.fragile['tests'] = self.ini['fragile']
 
-        self.parse_bool_opt('use_unix_sockets', False)
         self.parse_bool_opt('use_unix_sockets_iproto', False)
         self.parse_bool_opt('is_parallel', False)
         self.parse_bool_opt('show_reproduce_content', True)

--- a/test/test-app/suite.ini
+++ b/test/test-app/suite.ini
@@ -2,4 +2,3 @@
 core = app
 description = application tests
 is_parallel = True
-use_unix_sockets_iproto = True

--- a/test/test-tarantool/suite.ini
+++ b/test/test-tarantool/suite.ini
@@ -2,5 +2,4 @@
 core = tarantool
 description = tarantool tests
 script = box.lua
-use_unix_sockets = True
 config = engine.cfg

--- a/test/unittest/suite.ini
+++ b/test/unittest/suite.ini
@@ -2,5 +2,4 @@
 core = tarantool
 description = unit tests
 script = box-cc0544b6afd1.lua
-use_unix_sockets = True
 use_unix_sockets_iproto = True

--- a/test/unittest/test_lib_utils.py
+++ b/test/unittest/test_lib_utils.py
@@ -1,31 +1,13 @@
-import socket
 import unittest
 
-from hypothesis import given, settings
-from hypothesis.strategies import integers
-
 import lib.utils as utils
+
 
 class TestUtils(unittest.TestCase):
     def test_extract_schema_from_snapshot(self):
         snapshot_path = 'test/unittest/00000000000000000003.snap'
         v = utils.extract_schema_from_snapshot(snapshot_path)
         self.assertEqual(v, (2, 3, 1))
-
-    @settings(max_examples=5)
-    @given(port=integers(65100, 65535))
-    def test_check_port(self, port):
-        def open_socket(p):
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.bind(('localhost', p))
-            s.listen(0)
-            return s
-        status = utils.check_port(port, rais=False, ipv4=True, ipv6=False)
-        self.assertEqual(status, True)
-        s = open_socket(port)
-        status = utils.check_port(port, rais=False, ipv4=True, ipv6=False)
-        s.close()
-        self.assertEqual(status, False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change replaces manual choosing an iproto port for TarantoolServer
by the auto resolving mechanism. In two words, test-run always provides
'127.0.0.1:0' as a value for LISTEN env variable that is used in a lua
file to start a tarantool instance. In this way, the port will be picked
automatically, and we are getting the real value of it via the admin
console by executing `box.info.listen` that is available for tarantool
version >= 2.4.1, and special lua script intended for tarantool version
< 2.4.1.

The same for AppServer, test-run always provides '127.0.0.1:0' as a
value for LISTEN env variable that is used in a lua test script. In
this way, the iproto port will be picked automatically, but if the test
needs the real value of the port, it has to execute `box.info.listen`
for tarantool version >= 2.4.1, or other lua code for tarantool version
< 2.4.1.

Fixes #141