### PR TITLE
Fix determination of debug build

### DIFF
--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -224,7 +224,7 @@ class AppServer(Server):
     def find_exe(cls, builddir):
         cls.builddir = builddir
         cls.binary = TarantoolServer.binary
-        cls.debug = bool(re.findall(r'-Debug', str(cls.version()),
+        cls.debug = bool(re.findall(r'^Target:.*-Debug$', str(cls.version()),
                                     re.I))
 
     @staticmethod

--- a/lib/luatest_server.py
+++ b/lib/luatest_server.py
@@ -90,7 +90,7 @@ class LuatestServer(Server):
     def find_exe(cls, builddir):
         cls.builddir = builddir
         cls.binary = TarantoolServer.binary
-        cls.debug = bool(re.findall(r'-Debug', str(cls.version()),
+        cls.debug = bool(re.findall(r'^Target:.*-Debug$', str(cls.version()),
                                     re.I))
 
     @classmethod

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -727,8 +727,8 @@ class TarantoolServer(Server):
                         ctl_dir + '/?.lua;' + \
                         ctl_dir + '/?/init.lua;' + \
                         os.environ.get("LUA_PATH", ";;")
-                cls.debug = bool(re.findall(r'-Debug', str(cls.version()),
-                                 re.I))
+                cls.debug = bool(re.findall(r'^Target:.*-Debug$', str(cls.version()),
+                                            re.I))
                 return exe
         raise RuntimeError("Can't find server executable in " + path)
 

--- a/lib/unittest_server.py
+++ b/lib/unittest_server.py
@@ -62,7 +62,7 @@ class UnittestServer(Server):
     def find_exe(cls, builddir):
         cls.builddir = builddir
         cls.binary = TarantoolServer.binary
-        cls.debug = bool(re.findall(r'-Debug', str(cls.version()),
+        cls.debug = bool(re.findall(r'^Target:.*-Debug$', str(cls.version()),
                                     re.I))
 
     @staticmethod


### PR DESCRIPTION
Determination of debug build uses an incorrect regular expression: since it uses `re.I` flag (case insensitivity), it can match compiler flags contained in the version string, e.g. '--Wa,--debug-prefix-map==' — remove this flag and make the regular expression more specific.

Closes #352