### PR TITLE
Fix detection of debug builds

### DIFF
--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -225,7 +225,7 @@ class AppServer(Server):
         cls.builddir = builddir
         cls.binary = TarantoolServer.binary
         cls.debug = bool(re.findall(r'^Target:.*-Debug$', str(cls.version()),
-                                    re.I))
+                                    re.M))
 
     @staticmethod
     def find_tests(test_suite, suite_path):

--- a/lib/luatest_server.py
+++ b/lib/luatest_server.py
@@ -91,7 +91,7 @@ class LuatestServer(Server):
         cls.builddir = builddir
         cls.binary = TarantoolServer.binary
         cls.debug = bool(re.findall(r'^Target:.*-Debug$', str(cls.version()),
-                                    re.I))
+                                    re.M))
 
     @classmethod
     def verify_luatest_exe(cls):

--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -728,19 +728,21 @@ class TarantoolServer(Server):
                         ctl_dir + '/?/init.lua;' + \
                         os.environ.get("LUA_PATH", ";;")
                 cls.debug = bool(re.findall(r'^Target:.*-Debug$', str(cls.version()),
-                                            re.I))
+                                            re.M))
                 return exe
         raise RuntimeError("Can't find server executable in " + path)
 
     @classmethod
     def print_exe(cls):
-        color_stdout('Tarantool server information\n', schema='info')
+        color_stdout('Tarantool server information:\n', schema='info')
         if cls.binary:
             color_stdout(' | Found executable at {}\n'.format(cls.binary))
         if cls.ctl_path:
             color_stdout(' | Found tarantoolctl at {}\n'.format(cls.ctl_path))
         color_stdout('\n' + prefix_each_line(' | ', cls.version()) + '\n',
                      schema='version')
+        color_stdout('Detected build mode: {}\n'.format(
+                     'Debug' if cls.debug else 'Release'), schema='info')
 
     def install(self, silent=True):
         if self._start_against_running:

--- a/lib/unittest_server.py
+++ b/lib/unittest_server.py
@@ -63,7 +63,7 @@ class UnittestServer(Server):
         cls.builddir = builddir
         cls.binary = TarantoolServer.binary
         cls.debug = bool(re.findall(r'^Target:.*-Debug$', str(cls.version()),
-                                    re.I))
+                                    re.M))
 
     @staticmethod
     def find_tests(test_suite, suite_path):


### PR DESCRIPTION
The `tarantool -v` output is a single multiline string. Flag re.MULTILINE is required to match it with start of line (`^`) or end of line (`$`) characters. The `.*` in the middle of the pattern does not match start/end of lines, so this expression can not match something like this:

```
Target: Darwin-x86_64-Release
Build options: ... -Debug ...
```

The re.IGNORECASE is not required, because the build mode is always spelled in one particular way: `-Debug`.

Follow-up to #352
Fixes #355

Co-authored-by: Serge Petrenko <sergepetrenko@tarantool.org>