### PR TITLE
Bump luatest to 0.5.7-17-g1387aa8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository ) &&
         ( github.repository == 'tarantool/test-run' )
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
New version includes the following commits:

- Print Tarantool version used by luatest [1]
- Change `coverage_report` parameter type to boolean [2]
- Forbid negative values for -r,--repeat option [3]
- Add new module server_v2.lua [4]
- Add --repeat-group option [5]
- Slightly prettify docs in server_v2.lua for LDoc [6]
- Merge server_v2.lua into server.lua [7]

[1] https://github.com/tarantool/luatest/commit/7b4acaaff5d65cf56b63cb2bafb45a81cd67dcc5 
[2] https://github.com/tarantool/luatest/commit/9cd0bf75cf2c0f0e11c03bfc07676b5412bca112 
[3] https://github.com/tarantool/luatest/commit/8c1f45561da2c3ad1f4656bd1a4405d585d3b7c6 
[4] https://github.com/tarantool/luatest/commit/287fb815c49555abf074a72e45aef0840f93f69f
[5] https://github.com/tarantool/luatest/commit/f07ab530d9ff19a55b69316b577cb325f97b3fb9
[6] https://github.com/tarantool/luatest/commit/f2dc273f1ff884c1943f3003ff75eb6109a68f5b
[7] https://github.com/tarantool/luatest/commit/e58676fe5cbe5916aa9062095d5b5e66741611df

Part of tarantool/luatest#239