### PR TITLE
get_cluster_vclock: delete zero vclock component

### DIFF
--- a/test_run.lua
+++ b/test_run.lua
@@ -224,6 +224,7 @@ local function get_cluster_vclock(self, servers)
             end
         end
     end
+    vclock[0] = nil
     return setmetatable(vclock, { __serialize = 'map' })
 end
 


### PR DESCRIPTION
Zero vclock component is used for local transactions and is meaningless for cluster as a whole. Lets just delete it before returning the cluster vclock.