### PR TITLE
consistent mode: fix worker's vardir calculation

### DIFF
--- a/lib/worker.py
+++ b/lib/worker.py
@@ -49,9 +49,22 @@ def parse_reproduce_file(filepath):
     return reproduce
 
 
+def main_vardir():
+    """
+    A 'var directory' term is used in two different meanings
+    across test-run.
+
+    There is the --vardir option, VARDIR environment variable and
+    /tmp/t default. Let's call this directory the 'main vardir'.
+
+    There are per worker subdirectories within the main vardir:
+    'ddd-suite-name'. Let's call such a directory worker's vardir.
+    """
+    return os.path.realpath(Options().args.vardir)
+
+
 def get_reproduce_file(worker_name):
-    main_vardir = os.path.realpath(Options().args.vardir)
-    reproduce_dir = os.path.join(main_vardir, 'reproduce')
+    reproduce_dir = os.path.join(main_vardir(), 'reproduce')
     return os.path.join(reproduce_dir, '%s.list.yaml' % worker_name)
 
 
@@ -255,8 +268,7 @@ class Worker:
         self.suite = suite
         self.name = '%03d_%s' % (self.id, self.suite.suite_path)
 
-        main_vardir = self.suite.ini['vardir']
-        self.suite.ini['vardir'] = os.path.join(main_vardir, self.name)
+        self.suite.ini['vardir'] = os.path.join(main_vardir(), self.name)
 
         self.reproduce_file = get_reproduce_file(self.name)
         safe_makedirs(os.path.dirname(self.reproduce_file))


### PR DESCRIPTION
#330 describes a problem with searching a Lua module in the consistent mode:

```
./test/test-run.py sql-tap/collation -j -1
```

However, the same tests is working in the parallel mode with one worker process:

```
./test/test-run.py sql-tap/collation -j 1
```

First of all, the `sql-tap/collation` argument actually matches two tests:

* `sql-tap/collation_unicode.test.lua`
* `sql-tap/collation.test.lua`

The latter is marked as fragile, while the former has no such mark. test-run places them in two different task groups, which are served by two different worker instances. However, the test suite object is shared between them.

A worker's vardir is calculated as `suite's vardir + worker_name` and it is set back to the suite's vardir. This code is written in assumption that a test suite contains the main vardir before worker's initialization.

This assumption works for the parallel mode, because of two facts:

* The suite object is created with the main vardir as vardir.
* The suite object is copied into a worker's process and so it is never changed twice.

The latter property is not hold in the consistent mode. We create `001-sql-tap` worker for stable tests and then another `001-sql-tap` for fragile tests. And they're in the same process for the consistent mode.

It results to worker's vardir like `/tmp/t/001-sql-tap/001-sql-tap`. However, the needed Lua module resides in `/tmp/t/001-sql-tap`.

Let's just acquire the main vardir directly from arguments list.

The problem was overlooked when a separate fragile test group was added. The consistent mode did assumption that one worker is created for one test suite, while it is not so anymore.

This double initialization of the test suite's vardir is actually an effect of parallelization of test-run. A lot of code already exist before the parallelization was implemented and it was not carefully redesigned.

Fixes #330