### PR TITLE
Drop setting OMP_NUM_THREADS

### DIFF
--- a/test-run.py
+++ b/test-run.py
@@ -323,10 +323,6 @@ if __name__ == "__main__":
 
         __builtins__.open = open_as_utf8
 
-    # don't sure why, but it values 1 or 2 gives 1.5x speedup for parallel
-    # test-run (and almost doesn't affect consistent test-run)
-    os.environ['OMP_NUM_THREADS'] = '2'
-
     status = 0
 
     if Options().args.show_tags:


### PR DESCRIPTION
It was workaround before https://github.com/tarantool/tarantool/issues/2431 was fixed (see comment [1] in the issue). Now we are going to drop sort using OpenMP so it is time to drop this workaround altogether.

[1] https://github.com/tarantool/tarantool/issues/2431#issuecomment-856007551

Part of https://github.com/tarantool/tarantool/issues/3389