### PR TITLE
app+luatest: eliminate stdout buffering and stream mixing problems

### DIFF
--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -125,10 +125,18 @@ class AppServer(Server):
         return os.path.join(self.vardir, file_name)
 
     def prepare_args(self, args=[]):
-        cli_args = [os.path.join(os.getcwd(), self.current_test.name)] + args
+        # Disable stdout bufferization.
+        cli_args = [self.binary, '-e', "io.stdout:setvbuf('no')"]
+
+        # Disable schema upgrade if requested.
         if self.disable_schema_upgrade:
-            cli_args = [self.binary, '-e',
-                        self.DISABLE_AUTO_UPGRADE] + cli_args
+            cli_args.extend(['-e', self.DISABLE_AUTO_UPGRADE])
+
+        # Add path to the script (the test).
+        cli_args.extend([os.path.join(os.getcwd(), self.current_test.name)])
+
+        # Add extra args if provided.
+        cli_args.extend(args)
 
         return cli_args
 

--- a/lib/luatest_server.py
+++ b/lib/luatest_server.py
@@ -36,7 +36,7 @@ class LuatestTest(Test):
         """Execute test by luatest command
 
         Execute `luatest -c --verbose <name>_test.lua --output tap` command.
-        Use capture mode. Provide a verbose output in the tap format.
+        Disable capture mode. Provide a verbose output in the tap format.
         Extend the command by `--pattern <pattern>` if the corresponding
         option is provided.
         """

--- a/lib/luatest_server.py
+++ b/lib/luatest_server.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 
-from subprocess import Popen, PIPE
+from subprocess import Popen
 from threading import Timer
 
 from lib.colorer import color_stdout
@@ -59,12 +59,12 @@ class LuatestTest(Test):
         project_dir = os.environ['SOURCEDIR']
 
         with open(server.logfile, 'ab') as f:
-            proc = Popen(command, cwd=project_dir, stdout=PIPE, stderr=f)
+            proc = Popen(command, cwd=project_dir, stdout=sys.stdout, stderr=f)
         sampler.register_process(proc.pid, self.id, server.name)
         test_timeout = Options().args.test_timeout
         timer = Timer(test_timeout, timeout_handler, (proc, test_timeout))
         timer.start()
-        sys.stdout.write_bytes(proc.communicate()[0])
+        proc.wait()
         timer.cancel()
         if proc.returncode != 0:
             raise TestExecutionError

--- a/lib/luatest_server.py
+++ b/lib/luatest_server.py
@@ -102,10 +102,6 @@ class LuatestServer(Server):
         # Put into vardir.
         return os.path.join(self.vardir, file_name)
 
-    @property
-    def binary(self):
-        return LuatestServer.prepare_args(self)[0]
-
     def deploy(self, vardir=None, silent=True, wait=True):
         self.vardir = vardir
         if not os.access(self.vardir, os.F_OK):

--- a/lib/server.py
+++ b/lib/server.py
@@ -143,17 +143,31 @@ class Server(object):
     def restart(self):
         pass
 
-    def print_log(self, lines=None):
-        msg = ('\n{prefix} of Tarantool Log file [Instance "{instance}"]' +
-               '[{logfile}]:\n').format(
-            prefix="Last {0} lines".format(lines) if lines else "Output",
-            instance=self.name,
-            logfile=self.logfile or 'null')
-        color_stdout(msg, schema='error')
-        if os.path.exists(self.logfile):
-            print_tail_n(self.logfile, lines)
+    def print_log(self, num_lines=None):
+        """ Show information from the given log file.
+        """
+        prefix = '\n[test-run server "{instance}"] '.format(instance=self.name)
+        if not self.logfile:
+            msg = 'No log file is set (internal test-run error)\n'
+            color_stdout(prefix + msg, schema='error')
+        elif not os.path.exists(self.logfile):
+            fmt_str = 'The log file {logfile} does not exist\n'
+            msg = fmt_str.format(logfile=self.logfile)
+            color_stdout(prefix + msg, schema='error')
+        elif os.path.getsize(self.logfile) == 0:
+            fmt_str = 'The log file {logfile} has zero size\n'
+            msg = fmt_str.format(logfile=self.logfile)
+            color_stdout(prefix + msg, schema='error')
+        elif num_lines:
+            fmt_str = 'Last {num_lines} lines of the log file {logfile}:\n'
+            msg = fmt_str.format(logfile=self.logfile, num_lines=num_lines)
+            color_stdout(prefix + msg, schema='error')
+            print_tail_n(self.logfile, num_lines)
         else:
-            color_stdout("    Can't find log:\n", schema='error')
+            fmt_str = 'The log file {logfile}:\n'
+            msg = fmt_str.format(logfile=self.logfile)
+            color_stdout(msg, schema='error')
+            print_tail_n(self.logfile, num_lines)
 
     @staticmethod
     def exclude_tests(test_names, exclude_patterns):

--- a/lib/test.py
+++ b/lib/test.py
@@ -91,6 +91,11 @@ class FilteredStream:
     def flush(self):
         self.stream.flush()
 
+    def fileno(self):
+        """ May be used for direct writting. Discards any filters.
+        """
+        return self.stream.fileno()
+
 
 def get_filename_by_test(postfix, test_name):
     """For <..>/<name>_test.* or <..>/<name>.test.* return <name> + postfix


### PR DESCRIPTION
The patchset attempts to eliminate unnecessary bufferization and stdout/stderr streams mixing. It should improve observability in case of a failure (#119) and stability for tests that intensively writes to stderr (#392).

* app+luatest: add `-e "io.stdout:setvbuf('no')"` to tarantool command-line arguments.
* app+luatest: don't collect stdout in the memory till process termination, but write it directly to the temporary result file.
* luatest: split stdout and stderr files to give the TAP13 parser more chances to understand the stdout correctly.

Fixes #119
Fixes #392

----

I test it on small examples like the following:

```lua
$ cat test/app-tap/foo.test.lua
#!/usr/bin/env tarantool

local tap = require('tap')

local test = tap.test('foo')

while true do
    test:ok(true, 'foo foo foo')
    io.stderr:write('bar bar bar\n')
    require('fiber').sleep(1)
end
```

```lua
$ cat test/app-luatest/foo_test.lua 
local t = require('luatest')
local g = t.group()

g.test_foo = function()
    while true do
        t.assert_equals(1, 1)
        io.stderr:write('bar bar bar\n')
        require('fiber').sleep(1)
    end
end
```

And I didn't verify it on the real world tests.

So, please, accept the patches with caution.