### PR TITLE
lint: update flake8 to 5.*

### DIFF
--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -889,7 +889,7 @@ class TarantoolServer(Server):
                                         cwd=self.vardir,
                                         stdout=self.log_des,
                                         stderr=self.log_des)
-        del(self.log_des)
+        del self.log_des
 
         # Restore the actual PWD value.
         os.environ['PWD'] = os.getcwd()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 coverage==5.*
-flake8==3.7.9
+flake8==5.*
 hypothesis==4.*


### PR DESCRIPTION
Locally flake8 reports me a style problem that is not detected in CI. This is distracting. Let's update flake8 in CI and fix the style problem.

flake8==6.\* doesn't support Python 3.7, but we have it in CI. Left flake8==5.* for a while.