### PR TITLE
Fix bug when lua script name truncated by dot

### DIFF
--- a/lib/tarantool_server.py
+++ b/lib/tarantool_server.py
@@ -583,7 +583,7 @@ class TarantoolServer(Server):
                 delattr(self, '_script')
             return
         self._script = os.path.abspath(val)
-        self.name = os.path.basename(self._script).split('.')[0]
+        self.name = os.path.basename(self._script).rsplit(".", maxsplit=1)[0]
 
     @property
     def _admin(self):


### PR DESCRIPTION
Creating a lua diff test with a name containing a dot causes the name to be parsed incorrectly. Then an attempt is made to create an tarantool instance with an incorrect name, resulting in an error. This change fixes the bug.

Fixes #300 