### PR TITLE
Fix incorrect character in log file name

### DIFF
--- a/lib/app_server.py
+++ b/lib/app_server.py
@@ -116,9 +116,9 @@ class AppServer(Server):
     def logfile(self):
         # remove suite name using basename
         test_name = os.path.basename(self.current_test.name)
-        # add :conf_name if any
+        # add .conf_name if any
         if self.current_test.conf_name is not None:
-            test_name += ':' + self.current_test.conf_name
+            test_name += '.' + self.current_test.conf_name
         # add '.tarantool.log'
         file_name = test_name + '.tarantool.log'
         # put into vardir


### PR DESCRIPTION
Running jobs in tarantool-ci fails at the `action/upload-artifact` runtime if there are broken tests. The reason for the problem is that the path of the test artifacts file contains the `:` character when test has been parametrized.

Its **non-supported** character in the upload action. The action doesn't allow the following characters in artifact path: ",:,<,>,|,*,?. [^1]

To fix the problem, the `:` character has been replaced with `.`.

[^1]: https://github.com/actions/toolkit/blob/master/packages/artifact/docs/additional-information.md#non-supported-characters

Fixes https://github.com/tarantool/tarantool-qa/issues/90