### PR TITLE
Pin PyYAML version to `5.3.1`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-PyYAML==5.*
+# Pin pyyaml to 5.3.1 until yaml/pyyaml#724 is fixed.
+PyYAML==5.3.1
 gevent==21.*


### PR DESCRIPTION
For now PyYAML=5.4.1 cannot be installed in Python 3.10.12 environment due to recently released Cython 3.0.0 [1]. This causes builds to fail. Pinned the dependency version to 5.3.1 until the issue [2] is solved.

[1] https://github.com/cython/cython/releases/tag/3.0.0
[2] https://github.com/yaml/pyyaml/issues/724