### PR TITLE
Bump luatest to 0.5.7-48-g18859f6

### DIFF
--- a/lib/luatest_server.py
+++ b/lib/luatest_server.py
@@ -34,10 +34,10 @@ class LuatestTest(Test):
     def execute(self, server):
         """Execute test by luatest command
 
-        Execute `luatest -c --verbose <name>_test.lua --output tap` command.
-        Disable capture mode. Provide a verbose output in the tap format.
-        Extend the command by `--pattern <pattern>` if the corresponding
-        option is provided.
+        Execute `luatest -c --no-clean --verbose <name>_test.lua --output tap`
+        command. Disable capture mode and deletion of the var directory.
+        Provide a verbose output in the tap format. Extend the command by
+        `--pattern <pattern>` if the corresponding option is provided.
         """
         server.current_test = self
         script = os.path.join(os.path.basename(server.testdir), self.name)
@@ -47,7 +47,7 @@ class LuatestTest(Test):
         # Add luatest as the script.
         command.extend([server.luatest])
         # Add luatest command-line options.
-        command.extend(['-c', '--verbose', script, '--output', 'tap'])
+        command.extend(['-c', '--no-clean', '--verbose', script, '--output', 'tap'])
         if Options().args.pattern:
             for p in Options().args.pattern:
                 command.extend(['--pattern', p])


### PR DESCRIPTION
New version includes the following commits related to luatest functionality:

- Parse custom net box URI (Unix socket) correctly [1]
- Move creating required resources to start funcs [2]
- Group some if conditions from `Server:initialize` [3]
- Not delete server's workdir in Server:drop() [4]
    
[1] tarantool/luatest@869ba1c
[2] tarantool/luatest@7d1358c
[3] tarantool/luatest@a188577
[4] tarantool/luatest@18859f6