### PR TITLE
requirements: bump gevent to 22.10.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         tarantool-version: ['2.8', '2.10']
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
-        tarantool-version: ['2.8', '2.10']
+        tarantool-version: ['2.8', '2.10', '2.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         tarantool-version: ['2.8', '2.10']
 
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Pin pyyaml to 5.3.1 until yaml/pyyaml#724 is fixed.
 PyYAML==5.3.1
-gevent==21.*
+gevent==22.10.2


### PR DESCRIPTION
- requirements: bump gevent to 22.10.2
- ci: add testing against Python 3.11
- ci: add testing against Python 3.12
- ci: add testing against Tarantool 2.11