### PR TITLE
requirements: bump PyYAML to 6.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-# Pin pyyaml to 5.3.1 until yaml/pyyaml#724 is fixed.
-PyYAML==5.3.1
+PyYAML==6.0.1
 gevent==22.10.2


### PR DESCRIPTION
* The issue https://github.com/yaml/pyyaml/issues/724 is fixed, and it is time to update PyYAML.