### PR TITLE
Adjust test result report width to terminal size

### DIFF
--- a/lib/colorer.py
+++ b/lib/colorer.py
@@ -63,6 +63,28 @@ def final_report(*args, **kwargs):
         f.write(data)
 
 
+def separator(sep):
+    # Import from the function to avoid recursive import.
+    from lib.utils import terminal_columns
+
+    columns = terminal_columns()
+    color_stdout(sep * columns, '\n', schema='separator')
+
+
+def test_line(name, conf=None):
+    # Import from the function to avoid recursive import.
+    from lib.utils import terminal_columns
+    from lib.utils import just_and_trim
+
+    columns = terminal_columns()
+
+    color_stdout(just_and_trim(name, 47) + ' ', schema='t_name')
+
+    if conf is None:
+        conf = ''
+    color_stdout(just_and_trim(conf, columns - 67) + ' ', schema='test_var')
+
+
 class CSchema(object):
     objects = {}
 

--- a/lib/test_suite.py
+++ b/lib/test_suite.py
@@ -15,11 +15,11 @@ from lib import Options
 from lib.app_server import AppServer
 from lib.luatest_server import LuatestServer
 from lib.colorer import color_stdout
+from lib.colorer import test_line
 from lib.inspector import TarantoolInspector
 from lib.server import Server
 from lib.tarantool_server import TarantoolServer
 from lib.unittest_server import UnittestServer
-from lib.utils import just_and_trim
 
 
 class ConfigurationError(RuntimeError):
@@ -217,7 +217,7 @@ class TestSuite:
 
     def is_test_enabled(self, test, conf, server):
         test_name = os.path.basename(test.name)
-        tconf = '%s:%s' % (test_name, conf)
+        tconf = '%s:%s' % (test_name, conf or '')
         checks = [
             (True, self.ini["disabled"]),
             (not server.debug, self.ini["release_disabled"]),
@@ -264,16 +264,10 @@ class TestSuite:
         test.inspector = inspector
         test_name = os.path.basename(test.name)
         full_test_name = os.path.join(self.ini['suite'], test_name)
-        color_stdout(just_and_trim(full_test_name, 47) + ' ', schema='t_name')
-        # for better diagnostics in case of a long-running test
-
-        conf = ''
-        if test.run_params:
-            conf = test.conf_name
-        color_stdout(just_and_trim(conf, 15) + ' ', schema='test_var')
+        test_line(full_test_name, test.conf_name)
 
         start_time = time.time()
-        if self.is_test_enabled(test, conf, server):
+        if self.is_test_enabled(test, test.conf_name, server):
             short_status = test.run(server)
         else:
             color_stdout("[ disabled ]\n", schema='t_name')

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -24,6 +24,12 @@ except ImportError:
     # Python 2.7.
     from pipes import quote as _shlex_quote
 
+try:
+    # Python 3.3+.
+    from shutil import get_terminal_size
+except ImportError:
+    # Python 2.7.
+    get_terminal_size = None
 
 UNIX_SOCKET_LEN_LIMIT = 107
 
@@ -372,3 +378,9 @@ def prepend_path(p):
 
 def shlex_quote(s):
     return _shlex_quote(s)
+
+
+def terminal_columns():
+    if get_terminal_size:
+        return get_terminal_size().columns
+    return 80

--- a/test-run.py
+++ b/test-run.py
@@ -56,6 +56,8 @@ import time
 from lib import Options
 from lib import saved_env
 from lib.colorer import color_stdout
+from lib.colorer import separator
+from lib.colorer import test_line
 from lib.utils import find_tags
 from lib.utils import shlex_quote
 from lib.error import TestRunInitError
@@ -114,18 +116,18 @@ def main_loop_parallel():
 
     print_greetings()
 
-    color_stdout("\n", '=' * 86, "\n", schema='separator')
-    color_stdout("WORKR".ljust(6),     schema='t_name')
-    color_stdout("TEST".ljust(48),     schema='t_name')
-    color_stdout("PARAMS".ljust(16),   schema='test_var')
-    color_stdout("RESULT\n",           schema='test_pass')
-    color_stdout('-' * 81, "\n",       schema='separator')
+    color_stdout('\n')
+    separator('=')
+    color_stdout('WORKR ', schema='t_name')
+    test_line('TEST', 'RARAMS')
+    color_stdout('RESULT\n', schema='test_pass')
+    separator('-')
 
     try:
         is_force = Options().args.is_force
         dispatcher.wait()
         dispatcher.wait_processes()
-        color_stdout('-' * 81, "\n", schema='separator')
+        separator('-')
         has_failed, has_flaked = dispatcher.statistics.print_statistics()
         has_undone = dispatcher.report_undone(
             verbose=bool(is_force or not has_failed))
@@ -136,12 +138,12 @@ def main_loop_parallel():
         if has_undone:
             return EXIT_NOTDONE_TEST
     except KeyboardInterrupt:
-        color_stdout('-' * 81, "\n", schema='separator')
+        separator('-')
         dispatcher.statistics.print_statistics()
         dispatcher.report_undone(verbose=False)
         raise
     except HangError:
-        color_stdout('-' * 81, "\n", schema='separator')
+        separator('-')
         dispatcher.statistics.print_statistics()
         dispatcher.report_undone(verbose=False)
         return EXIT_HANG
@@ -167,11 +169,11 @@ def main_loop_consistent(failed_test_ids):
 
     for name, task_group in task_groups:
         # print information about current test suite
-        color_stdout("\n", '=' * 80, "\n", schema='separator')
-        color_stdout("TEST".ljust(48),     schema='t_name')
-        color_stdout("PARAMS".ljust(16),   schema='test_var')
-        color_stdout("RESULT\n",           schema='test_pass')
-        color_stdout('-' * 75, "\n",       schema='separator')
+        color_stdout('\n')
+        separator('=')
+        test_line('TEST', 'RARAMS')
+        color_stdout("RESULT\n", schema='test_pass')
+        separator('-')
 
         task_ids = task_group['task_ids']
         show_reproduce_content = task_group['show_reproduce_content']
@@ -198,7 +200,7 @@ def main_loop_consistent(failed_test_ids):
                     worker.stop_server(cleanup=False)
                     return
 
-        color_stdout('-' * 75, "\n", schema='separator')
+        separator('-')
 
         worker.stop_server(silent=False)
         color_stdout()


### PR DESCRIPTION
Now the test configuration name is not trimmed if the terminal width allows it.

The idea can be illustrated this way:

```
+----------------------------------------------------------------------+
| Wide terminal                                                        |
+----------------------------------------------------------------------+
| suite/mytest_test.lua my_configuration                  [ pass ]     |
+----------------------------------------------------------------------+

+-------------------------------------------------+
| Narrow terminal                                 |
+-------------------------------------------------+
| suite/mytest_test.lua my_configur> [ pass ]     |
+-------------------------------------------------+
```

I want to add support for ability to run test cases as separate parallel tasks for luatest based tests with reporting of the test case name as a test configuration to the terminal. The test case names sometimes are quite long and it is convenient to see as much symbols from it as possible.

At the same time, the configuration name is stripped if the terminal has a low width. This way the output look good as on a wide as well as on a narrow terminal.

The feature works on Python 3.3+.