### PR TITLE
Calculate parallel jobs based on available CPUs

### DIFF
--- a/test-run.py
+++ b/test-run.py
@@ -58,6 +58,7 @@ from lib import saved_env
 from lib.colorer import color_stdout
 from lib.colorer import separator
 from lib.colorer import test_line
+from lib.utils import cpu_count
 from lib.utils import find_tags
 from lib.utils import shlex_quote
 from lib.error import TestRunInitError
@@ -86,7 +87,7 @@ def main_loop_parallel():
     jobs = args.jobs
     if jobs < 1:
         # faster result I got was with 2 * cpu_count
-        jobs = 2 * multiprocessing.cpu_count()
+        jobs = 2 * cpu_count()
 
     if jobs > 0:
         color_stdout("Running in parallel with %d workers\n\n" % jobs,


### PR DESCRIPTION
We're going to enable new ARM64 runners in CI, where test-run is invoked in a Docker container. At the same time, the runner is an LXD container created by the service provider. In this circumstances, the Docker container sees all the 128 online CPUs, but the runner may have only some of them available (depending on the pricing plan).

Python 3.3+ has a function to determine available CPUs, so we can reduce the parallelism to this value. We fall back to the online CPUs count on Python < 3.3.

After this change, test-run follows a CPU affinity mask set by `taskset` (and, I guess, by `numactl`).

The change is similar to replacing `nproc --all` to `nproc`.

The change only affects the default behavior, which can be overwritten by passing the `--jobs` (or `-j`) CLI option or using the `TEST_RUN_JOBS` environment variable.

Reported in https://github.com/tarantool/tarantool/pull/10102