### PR TITLE
Fail if core=tarantool default server failed

### DIFF
--- a/lib/test.py
+++ b/lib/test.py
@@ -218,6 +218,7 @@ class Test(object):
         sys.stdout.flush()
 
         is_tap = False
+        is_crashed = False
         if not self.skip:
             if not os.path.exists(self.tmp_result):
                 self.is_executed_ok = False
@@ -233,6 +234,9 @@ class Test(object):
                 is_tap, is_ok, is_skip = self.check_tap_output()
                 self.is_equal_result = is_ok
                 self.skip = is_skip
+
+            server.stop(silent=True)
+            is_crashed = server.current_test.is_crash_reported
         else:
             self.is_equal_result = 1
 
@@ -250,7 +254,8 @@ class Test(object):
                 os.remove(self.tmp_result)
         elif (self.is_executed_ok and
               self.is_equal_result and
-              self.is_valgrind_clean):
+              self.is_valgrind_clean and
+              not is_crashed):
             short_status = 'pass'
             color_stdout("[ pass ]\n", schema='test_pass')
             if os.path.exists(self.tmp_result):


### PR DESCRIPTION
Currently we stop default server in worker run loop only before the next test start. So the previous test does not account whether the Tarantool executing the test exits successfully or not. Thus we do not fail on memory leaks for example.

Let's stop the server and account its exit status in test.

Closes #416