### PR TITLE
Follow-up fix for parsing non-utf8 chars

### DIFF
--- a/listeners.py
+++ b/listeners.py
@@ -459,7 +459,7 @@ class HangWatcher(BaseWatcher):
             result_file = task.task_tmp_result
             result_file_summary = '(no result file {})'.format(result_file)
             if os.path.exists(result_file):
-                with open(result_file, 'r') as f:
+                with open(result_file, 'r', encoding='utf-8', errors='replace') as f:
                     lines = sum(1 for _ in f)
                     result_file_summary = 'at {}:{}'.format(result_file,
                                                             lines)


### PR DESCRIPTION
Previous attempt to fix this in commit 72905405cebe ("tap13: fix parsing non-utf8 chars") didn't take into account the hung test reporter, which also reads the result file in order to report how many lines into the result the test hung. Fix this as well.

Closes #442