### PR TITLE
Follow-up fix for parsing non-utf8 chars (part 2)

### DIFF
--- a/lib/test.py
+++ b/lib/test.py
@@ -228,7 +228,8 @@ class Test(object):
             elif self.is_executed_ok:
                 if Options().args.is_verbose:
                     color_stdout('\n')
-                    with open(self.tmp_result, 'r') as f:
+                    with open(self.tmp_result, 'r', encoding='utf-8',
+                              errors='replace') as f:
                         color_stdout(f.read(), schema='log')
                 is_tap, is_ok, is_skip = self.check_tap_output()
                 self.is_equal_result = is_ok


### PR DESCRIPTION
This patch is similar to commit 52d3e4f7c90f ("Follow-up fix for parsing non-utf8 chars"),
but fixes the `--verbose` output, e.g.:

```
$ ./test-run.py --verbose some_test

[...]
[001] Worker "001_xxx-luatest" received the following error; stopping...
[001] Traceback (most recent call last):
[001]   File "./tarantool/test-run/lib/worker.py", line 357, in run_task
[001]     short_status, duration = self.suite.run_test(
[001]                              ^^^^^^^^^^^^^^^^^^^^
[001]   File "./tarantool/test-run/lib/test_suite.py", line 271, in run_test
[001]     short_status = test.run(server)
[001]                    ^^^^^^^^^^^^^^^^
[001]   File "./tarantool/test-run/lib/test.py", line 232, in run
[001]     color_stdout(f.read(), schema='log')
[001]                  ^^^^^^^^
[001]   File "<frozen codecs>", line 322, in decode
[001] UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa3 in position 115111: invalid start byte
[001]
[001] Exception: 'utf-8' codec can't decode byte 0xa3 in position 115111: invalid start byte
```

Follow-up #442