### PR TITLE
Bump luatest to 1.0.1-34-b446120

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Pin pyyaml to 5.3.1 until yaml/pyyaml#724 is fixed.
 PyYAML==5.3.1
-gevent==22.10.2
+gevent==22.10.2; python_version <= '3.8'
+gevent==24.11.1; python_version > '3.8'


### PR DESCRIPTION
New version includes the following commits related to luatest functionality:

- Add `cluster` helper as a tool for managing a Tarantool cluster [1]

[1] tarantool/luatest@b446120