### PR TITLE
test: refactor hooks for luatest API change

### DIFF
--- a/test/test-luatest/smoke_check_test.lua
+++ b/test/test-luatest/smoke_check_test.lua
@@ -4,18 +4,18 @@ local server = require('test.luatest_helpers.server')
 
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({
         alias = 'my_server',
         env = {MY_ENV_VAR = 'test_value'},
         box_cfg = {memtx_memory = 100 * 1024 ^ 2},
     })
     g.server:start()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     g.server:stop()
-end
+end)
 
 g.test_server_is_started_and_operable = function()
     local res = g.server:eval('return 42')


### PR DESCRIPTION
Luatest now forbids direct hook assignment, so tests using `g.before_all = fn`, `g.after_all = fn`, etc. must be rewritten to the call-style API. This patch updates them accordingly.

Follow-up tarantool/tarantool#8187
Follow-up tarantool/luatest#390