### PR TITLE
Remove LUA_PATH provided to luatest

### DIFF
--- a/bin/luatest
+++ b/bin/luatest
@@ -1,20 +1,5 @@
 #!/usr/bin/env tarantool
 
---
--- Add the luatest module to LUA_PATH so that it can be used in processes
--- spawned by tests.
---
-local fio = require('fio')
-local path = package.search('luatest')
-if path == nil then
-    error('luatest not found')
-end
-path = fio.dirname(path) -- strip init.lua
-path = fio.dirname(path) -- strip luatest
-os.setenv('LUA_PATH',
-          path .. '/?.lua;' .. path .. '/?/init.lua;' ..
-          (os.getenv('LUA_PATH') or ';'))
-
 print(('Tarantool version is %s'):format(require('tarantool').version))
 
 require('luatest.cli_entrypoint')()


### PR DESCRIPTION
There is no need to specify `LUA_PATH` anymore, since starting with luatest 1.4.3 the Tarantool `package.searchroot` mechanism is supported.