### PR TITLE
Use luatest from parent directory if available

### DIFF
--- a/bin/luatest
+++ b/bin/luatest
@@ -1,5 +1,25 @@
 #!/usr/bin/env tarantool
 
+--
+-- If luatest is present in the parent directory, add it to the search path.
+-- This is useful for projects that are shipped with luatest as a submodule.
+-- Note that luatest installed from rocks still has a higher priority because
+-- Tarantool (in contrast to vanilla Lua and LuaJIT) loads rocks before modules
+-- located in LUA_PATH.
+--
+local fio = require('fio')
+local dir = fio.dirname(fio.abspath(arg[0]))
+dir = fio.dirname(dir) -- strip bin/
+dir = fio.dirname(dir) -- strip test-run/
+dir = fio.pathjoin(dir, 'luatest')
+if fio.path.is_dir(dir) then
+    local luatest_path = dir .. '/?.lua;' .. dir .. '/?/init.lua;'
+    package.path = luatest_path .. package.path
+    -- Add luatest to LUA_PATH as well so that it can be used in processes
+    -- spawned by tests.
+    os.setenv('LUA_PATH', luatest_path .. (os.getenv('LUA_PATH') or ';'))
+end
+
 print(('Tarantool version is %s'):format(require('tarantool').version))
 
 require('luatest.cli_entrypoint')()


### PR DESCRIPTION
Currently, test-run requires luatest to be installed from rocks. It is okay for most tarantool-based projects but it isn't really convenient for tarantool itself: in order to install luatest from rocks, one has to install the tt and tarantool packages because tt will refuse to install anything from rocks if tarantool binary or headers are unavailable. This means that to test a freshly built tarantool, one has to install tarantool first, which sounds strange. True, one can make tt use a freshly built tarantool's binary and headers, but it's tricky. Let's instead make test-run use luatest from the parent directory and ship luatest as a submodule in the main Tarantool repository. Note, that if there's luatest installed from rocks in the current source tree, it will still have a higher priority.