### PR TITLE
test-run: show luatest stderr on startup failure

### DIFF
--- a/lib/luatest_server.py
+++ b/lib/luatest_server.py
@@ -131,14 +131,20 @@ class LuatestServer(Server):
     def verify_luatest_exe(cls):
         """Verify that luatest executable is available."""
         try:
-            # Just check that the command returns zero exit code.
+            # Check that the command returns zero exit code.
+            # Capture stderr to show the actual error if luatest
+            # fails to start.
             with open(os.devnull, 'w') as devnull:
-                returncode = Popen([cls.luatest, '--version'],
-                                   stdout=devnull,
-                                   stderr=devnull).wait()
+                proc = Popen([cls.luatest, '--version'],
+                             stdout=devnull,
+                             stderr=PIPE)
+                stderr = bytes_to_str(proc.stderr.read()).rstrip()
+                returncode = proc.wait()
             if returncode != 0:
-                raise TestRunInitError('Unable to run `luatest --version`',
-                                       {'returncode': returncode})
+                msg = 'Unable to run `luatest --version` (exit code %d)' % returncode
+                if stderr:
+                    msg += ':\n' + stderr
+                raise TestRunInitError(msg)
         except OSError as e:
             # Python 2 raises OSError if the executable is not
             # found or if it has no executable bit. Python 3


### PR DESCRIPTION
If luatest fails to start (e.g., due to a Lua error in one of the loaded modules), test-run only shows the exit code without the actual error message. Capture stderr from the subprocess and include it in the error message so the cause of the failure is visible right away.

This may result in verbose error output in some cases. Let me know if the original behavior of discarding stderr was intentional - I found it very inconvenient to debug without seeing the actual error message.